### PR TITLE
Add PowerTools v0.7.0 react plugin

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "plugins/SDH-SystemToolbox"]
 	path = plugins/SDH-SystemToolbox
 	url = https://github.com/WerWolv/SDH-SystemToolbox
+[submodule "plugins/PowerTools"]
+	path = plugins/PowerTools
+	url = https://github.com/NGnius/PowerTools


### PR DESCRIPTION
Commit is pretty self-explanatory. This is the first version of PowerTools using the new plugin system.

Do note that this uses a version on the dev branch of PowerTools which I've confirmed works. I'll update to a proper release version after the decky v2.0 official release, though I don't expect any changes to happen to PowerTools between now and then.

Oh also I'm not sure how you're handling legacy versions, but in case this could cause issues: I've changed the name in `plugin.json` from `Power Tools` to `PowerTools` (no space). I'm not too worried about legacy versions of PowerTools -- please don't worry about restoring links to <=0.6.0 if it does happen. This is just a heads-up.