### PR TITLE
add DeckFAQs (Decky Loader version) to new store

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "plugins/SDH-SystemToolbox"]
 	path = plugins/SDH-SystemToolbox
 	url = https://github.com/WerWolv/SDH-SystemToolbox
+[submodule "plugins/deckfaqs"]
+	path = plugins/deckfaqs
+	url = https://github.com/hulkrelax/deckfaqs


### PR DESCRIPTION
PR to add deckfaqs as a submodule to the decky plugin database