### PR TITLE
Add SDH-CssLoader v0.2.0 plugin

### DIFF
--- a/.github/workflows/build-plugins.yml
+++ b/.github/workflows/build-plugins.yml
@@ -69,7 +69,7 @@ jobs:
             files+=($(cut -d/ -f3 <<< $file))
           done
         else
-          (IFS=,;for file in ${{ steps.changed-files.outputs.all_changed_files }}; do
+          (IFS=,;for file in "${{ steps.changed-files.outputs.all_changed_files }}"; do
             files+=($(cut -d/ -f2 <<< $file))
           done)
         fi

--- a/.gitmodules
+++ b/.gitmodules
@@ -7,3 +7,6 @@
 [submodule "plugins/PowerTools"]
 	path = plugins/PowerTools
 	url = https://github.com/NGnius/PowerTools
+[submodule "plugins/SDH-CssLoader"]
+	path = plugins/SDH-CssLoader
+	url = https://github.com/suchmememanyskill/SDH-CssLoader


### PR DESCRIPTION
# Css Loader
This plugin loads .css from disk in an organised fashion, and injects it into the steam UI. Automatically reloads themes when the tab(s) css is injected into become unloaded. Comes bundled with 4 themes

## Checklist:

- [X] I am the original author of this plugin.
- [X] I made my code efficient and readable.
- [X] I have verified that my plugin works properly on the latest versions of SteamOS and decky-loader.
    - Verified using v2.0.4-f015e00-pre of the decky loader
- [X] I have verified that my plugin is unique and does not have the same functionality as another plugin on the store.
    - An old version of this plugin (v0.1.2) is listed on the plugin store. This should be overwritten by this plugin 
