### PR TITLE
Add Submodule for ProtonDB Medals v 0.5

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -10,3 +10,6 @@
 [submodule "plugins/SDH-CssLoader"]
 	path = plugins/SDH-CssLoader
 	url = https://github.com/suchmememanyskill/SDH-CssLoader
+[submodule "plugins/ProtonDBGameBadge"]
+	path = plugins/ProtonDBGameBadge
+	url = https://github.com/joamjoamjoam/ProtonDBGameBadge


### PR DESCRIPTION
# ProtonDB Medals

Adds ProtonDB Medals to each Game Screen. The Medals display the ProtonDB rating and include a link to the ProtonDB page.

## Checklist:

- [x] I am the original author of this plugin.
- [x] I made my code efficient and readable.
- [x] I have verified that my plugin works properly on the latest versions of SteamOS and decky-loader.
- [x] I have verified that my plugin is unique and does not have the same functionality as another plugin on the store.
