### PR TITLE
Add ProtonDB Badges v1.0.1

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -17,7 +17,7 @@
 [submodule "plugins/vibrantDeck"]
 	path = plugins/vibrantDeck
 	url = https://github.com/libvibrant/vibrantDeck.git
- [submodule "plugins/MusicControl"]
+[submodule "plugins/MusicControl"]
 	path = plugins/MusicControl
 	url = https://github.com/mirobouma/MusicControl.git
 [submodule "plugins/protondb-decky"]

--- a/.gitmodules
+++ b/.gitmodules
@@ -13,3 +13,6 @@
 [submodule "plugins/vibrantDeck"]
 	path = plugins/vibrantDeck
 	url = https://github.com/libvibrant/vibrantDeck.git
+[submodule "plugins/protondb-decky"]
+	path = plugins/protondb-decky
+	url = https://github.com/OMGDuke/protondb-decky


### PR DESCRIPTION
# ProtonDB Badges

Display tappable ProtonDB badges on your game pages

https://github.com/OMGDuke/protondb-decky

## Checklist:

- [x] I am the original author of this plugin.
- [x] I made my code efficient and readable.
- [x] I have verified that my plugin works properly on the latest versions of SteamOS and decky-loader.
- [x] I have verified that my plugin is unique and does not have the same functionality as another plugin on the store.
