### PR TITLE
Add MusicControl 1.0.0

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -17,3 +17,6 @@
 [submodule "plugins/vibrantDeck"]
 	path = plugins/vibrantDeck
 	url = https://github.com/libvibrant/vibrantDeck.git
+[submodule "plugins/MusicControl"]
+	path = plugins/MusicControl
+	url = https://github.com/mirobouma/MusicControl.git


### PR DESCRIPTION
# MusicControl

MusicControl allows you to control any playing media that implements the [MediaPlayer2.Player](https://specifications.freedesktop.org/mpris-spec/2.2/Player_Interface.html) DBUS interface.

The plugin executes some commands every second to synchronize the media player. Since i'm pretty new to JS/Python/Linux I'm not too sure how expensive those calls would be. If there are any suggestions to improve the performance i'm all ears :)
## Checklist:

- [x] I am the original author of this plugin.
- [X] I made my code efficient and readable.
- [x] I have verified that my plugin works properly on the latest versions of SteamOS and decky-loader.
- [x] I have verified that my plugin is unique and does not have the same functionality as another plugin on the store.
