### PR TITLE
Add SDH-PauseGames v0.1.0 plugin

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -20,3 +20,6 @@
 [submodule "plugins/MusicControl"]
 	path = plugins/MusicControl
 	url = https://github.com/mirobouma/MusicControl.git
+[submodule "plugins/SDH-PauseGames"]
+	path = plugins/SDH-PauseGames
+	url = https://github.com/popsUlfr/SDH-PauseGames.git


### PR DESCRIPTION
# Pause Games

This plugin makes it possible to pause and resume applications started from the Steam Deck UI.
It sends the `SIGSTOP` signal to all children of the reaper process to suspend execution and `SIGCONT` to resume.

Can be useful for when you want to suspend an app to redirect the cpu and gpu resources to another without outright killing the former.

v0.1.0

## Checklist:

- [x] I am the original author of this plugin.
- [x] I made my code efficient and readable.
- [x] I have verified that my plugin works properly on the latest versions of SteamOS and decky-loader.
- [x] I have verified that my plugin is unique and does not have the same functionality as another plugin on the store.
