### PR TITLE
Add Audio Loader (SDH-AudioLoader) 1.0.1

### DIFF
--- a/.github/workflows/build-plugins.yml
+++ b/.github/workflows/build-plugins.yml
@@ -84,6 +84,8 @@ jobs:
           printf "%s\n" "${files[@]}" | sort -u
         fi
         popd
+        IFS=$'\n' sorted=($(sort -u <<<"$${files[@]}"))
+        unset $IFS
         echo ::set-output name=edited_files::${files[@]}
     
     - name: Build plugin backends

--- a/.gitmodules
+++ b/.gitmodules
@@ -26,3 +26,6 @@
 [submodule "plugins/protondb-decky"]
 	path = plugins/protondb-decky
 	url = https://github.com/OMGDuke/protondb-decky
+[submodule "plugins/SDH-AudioLoader"]
+	path = plugins/SDH-AudioLoader
+	url = https://github.com/EMERALD0874/SDH-AudioLoader


### PR DESCRIPTION
# Audio Loader (SDH-AudioLoader)

This plugin allows users to replace sound effects played while navigating the Steam Deck UI with custom sound packs. Users can create and upload sound packs to [the pack database](https://github.com/EMERALD0874/AudioLoader-PackDB). Once approved, sound packs will appear in a pack browser integrated within the plugin. They can install packs from the browser and choose a sound pack to use in the plugin menu.

A future update will also allow users to download music packs that play outside of games. This is not a generic music player, but rather a way of playing music in menus similar to consoles like the 3DS, PS4, and others.

## Checklist:

- [x] I am the original author of this plugin.
- [x] I made my code efficient and readable.
- [x] I have verified that my plugin works properly on the latest versions of SteamOS and decky-loader.
- [x] I have verified that my plugin is unique and does not have the same functionality as another plugin on the store.
