### PR TITLE
Add Bluetooth 2.0.0

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -35,3 +35,6 @@
 [submodule "plugins/custom-mangohud"]
 	path = plugins/custom-mangohud
 	url = https://github.com/simons-public/custom-mangohud
+[submodule "plugins/Bluetooth"]
+	path = plugins/Bluetooth
+	url = https://github.com/Outpox/Bluetooth.git


### PR DESCRIPTION
# Bluetooth

Formerly known as SDH-Bluetooth, this plugin allows you to quickly connect and disconnect an already paired bluetooth devices.  

## Checklist:

- [x] I am the original author of this plugin.
- [x] I made my code efficient and readable.
- [x] I have verified that my plugin works properly on the latest versions of SteamOS and decky-loader.
- [x] I have verified that my plugin is unique and does not have the same functionality as another plugin on the store.
