### PR TITLE
Add SDH-Notebook v0.1.0 plugin

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -38,3 +38,6 @@
 [submodule "plugins/Bluetooth"]
 	path = plugins/Bluetooth
 	url = https://github.com/Outpox/Bluetooth.git
+[submodule "plugins/SDH-Notebook"]
+	path = plugins/SDH-Notebook
+	url = https://github.com/popsUlfr/SDH-Notebook.git


### PR DESCRIPTION
# Notebook

A plugin to quickly scribble down important codes or notes during your play sessions.

I kinda depends on https://github.com/SteamDeckHomebrew/decky-loader/pull/161 to be merged so that decky-loader doesn't throw exceptions when bigger datasets (> 64 kib) are passed to the backend (the custom POST/GET webserver backend is still in the git history of the plugin if needed though).

## Checklist:

- [x] I am the original author of this plugin.
- [x] I made my code efficient and readable.
- [x] I have verified that my plugin works properly on the latest versions of SteamOS and decky-loader.
- [x] I have verified that my plugin is unique and does not have the same functionality as another plugin on the store.
