### PR TITLE
WIP: Add RemotePlayWhatever Plugin

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -44,3 +44,6 @@
 [submodule "plugins/Fantastic"]
 	path = plugins/Fantastic
 	url = https://github.com/NGnius/Fantastic
+[submodule "plugins/RemotePlayWhatever"]
+	path = plugins/RemotePlayWhatever
+	url = https://github.com/joamjoamjoam/RemotePlayWhatever.git


### PR DESCRIPTION
# Remote  Play Whatever

Creates Remote Play Together Sessions for games that lack native support.

## Checklist:

- [X] I am the original author of this plugin.
- [X] I made my code efficient and readable.
- [X] I have verified that my plugin works properly on the latest versions of SteamOS and decky-loader.
- [X] I have verified that my plugin is unique and does not have the same functionality as another plugin on the store.
