### PR TITLE
Updating Remote Play Whatever to use the store to download remote bi…

### DIFF
--- a/.github/workflows/build-plugins.yml
+++ b/.github/workflows/build-plugins.yml
@@ -84,10 +84,10 @@ jobs:
           printf "%s\n" "${files[@]}" | sort -u
         fi
         popd
-        IFS=$'\n' sorted=($(sort -u <<<"$${files[@]}"))
+        IFS=$'\n' sorted=($(sort -u <<<"${files[@]}"))
         unset $IFS
         echo "${sorted[@]}"
-        echo ::set-output name=edited_files::${files[@]}
+        echo ::set-output name=edited_files::${sorted[@]}
     
     - name: Build plugin backends
       run: |

--- a/.github/workflows/build-plugins.yml
+++ b/.github/workflows/build-plugins.yml
@@ -169,7 +169,6 @@ jobs:
           hasbin="$(find $plugin -maxdepth 1 -type d -name 'bin' -printf '%P\n')"
           # Check if plugin has a defaults folder, if so, add "default" contents to root dir
           hasdefaults="$(find $plugin -maxdepth 1 -type d -name 'defaults' -printf '%P\n')"
-
           # Add required plugin files (and directory) to zip file
           echo "$plugin/dist $plugin/plugin.json $plugin/package.json"
           zip -r $zipname "$plugin/dist" "$plugin/plugin.json" "$plugin/package.json"

--- a/.github/workflows/build-plugins.yml
+++ b/.github/workflows/build-plugins.yml
@@ -169,25 +169,13 @@ jobs:
           hasbin="$(find $plugin -maxdepth 1 -type d -name 'bin' -printf '%P\n')"
           # Check if plugin has a defaults folder, if so, add "default" contents to root dir
           hasdefaults="$(find $plugin -maxdepth 1 -type d -name 'defaults' -printf '%P\n')"
-          # Check if plugin has a remote binary. Eat the non zero result if not
-          hasremotebin="$(cat ${plugin}/package.json | jq -e -s -r ".[].remote_binary")" || true
+
           # Add required plugin files (and directory) to zip file
           echo "$plugin/dist $plugin/plugin.json $plugin/package.json"
           zip -r $zipname "$plugin/dist" "$plugin/plugin.json" "$plugin/package.json"
           if [ ! -z "$hasbin" ]; then
             echo "$plugin/bin"
             zip -r $zipname "$plugin/bin"
-          fi
-
-          if [ ! "$hasremotebin" == "null"  ]; then
-            sudo chmod -R 777 $plugin
-            mkdir -p $plugin/bin
-            filename="$(basename $hasremotebin)"
-            curl -L "$hasremotebin" -o "$plugin/bin/$filename"
-            zip -r $zipname "$plugin/bin/$filename"
-          else
-            echo "hasremotebin: $hasremotebin"
-            echo "$plugin does not have remote binary"!
           fi
 
           if [ ! -z "$haspython" ]; then


### PR DESCRIPTION
# Remote Play Whatever

- Update plugin to use the decky store to download remote binaries
- Removed CI Remote Binary downloads in favor of doing them in the Decky Store.

Should be merged after: 
https://github.com/SteamDeckHomebrew/decky-loader/pull/177

## Checklist:

- [X] I am the original author of this plugin.
- [X] I made my code efficient and readable.
- [X] I have verified that my plugin works properly on the latest versions of SteamOS and decky-loader.
- [X] I have verified that my plugin is unique and does not have the same functionality as another plugin on the store.
