### PR TITLE
Update Memory Deck to v0.1.1

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -47,3 +47,6 @@
 [submodule "plugins/RemotePlayWhatever"]
 	path = plugins/RemotePlayWhatever
 	url = https://github.com/joamjoamjoam/RemotePlayWhatever.git
+[submodule "plugins/memory-deck"]
+	path = plugins/memory-deck
+	url = https://github.com/CameronRedmore/memory-deck.git


### PR DESCRIPTION
# Memory Deck

A few bug fixes to get Memory Deck working with the latest versions of Decky Loader.

## Checklist:

- [X] I am the original author of this plugin.
- [X] I made my code efficient and readable.
- [X] I have verified that my plugin works properly on the latest versions of SteamOS and decky-loader.
- [X] I have verified that my plugin is unique and does not have the same functionality as another plugin on the store.
