### PR TITLE
add hltb-for-deck v1.0.0

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -56,3 +56,6 @@
 [submodule "plugins/bash-shortcuts"]
 	path = plugins/bash-shortcuts
 	url = https://github.com/Tormak9970/bash-shortcuts.git
+[submodule "plugins/hltb-for-deck"]
+	path = plugins/hltb-for-deck
+	url = https://github.com/hulkrelax/hltb-for-deck


### PR DESCRIPTION
# HLTB for Deck v1.0.0

This plugin adds statistics on average play times according to data from How Long to Beat. The data is added to the library app page for a given game

## Checklist:

- [x] I am the original author of this plugin.
- [x] I made my code efficient and readable.
- [x] I have verified that my plugin works properly on the latest versions of SteamOS and decky-loader.
- [x] I have verified that my plugin is unique and does not have the same functionality as another plugin on the store.
