### PR TITLE
Add AutoSuspend

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -59,3 +59,6 @@
 [submodule "plugins/hltb-for-deck"]
 	path = plugins/hltb-for-deck
 	url = https://github.com/hulkrelax/hltb-for-deck
+[submodule "plugins/decky-autosuspend"]
+	path = plugins/decky-autosuspend
+	url = https://github.com/jurassicplayer/decky-autosuspend.git


### PR DESCRIPTION
# AutoSuspend

A plugin to notify (audio and toasts) and automatically suspend the steamdeck console when passing a battery percentage threshold.

## Checklist:

- [x] I am the original author of this plugin.
- [x] I made my code efficient and readable.
- [x] I have verified that my plugin works properly on the latest versions of SteamOS and decky-loader.
- [x] I have verified that my plugin is unique and does not have the same functionality as another plugin on the store.
