### PR TITLE
add SteamlessTimes

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -65,3 +65,6 @@
 [submodule "plugins/Emuchievements"]
 	path = plugins/Emuchievements
 	url = https://github.com/EmuDeck/Emuchievements
+[submodule "plugins/SteamlessTimes"]
+	path = plugins/SteamlessTimes
+	url = https://github.com/EmuDeck/SteamlessTimes


### PR DESCRIPTION
# SteamlessTimes

Plugin for keeping track of play time of non steam games. Part of the EmuDeck Project

## Checklist:

- [x] I am the original author of this plugin.
- [x] I made my code efficient and readable.
- [x] I have verified that my plugin works properly on the latest versions of SteamOS and decky-loader.
- [x] I have verified that my plugin is unique and does not have the same functionality as another plugin on the store.
