### PR TITLE
Add TunnelDeck

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -65,3 +65,6 @@
 [submodule "plugins/Emuchievements"]
 	path = plugins/Emuchievements
 	url = https://github.com/EmuDeck/Emuchievements
+[submodule "plugins/TunnelDeck"]
+	path = plugins/TunnelDeck
+	url = https://github.com/steve228uk/TunnelDeck


### PR DESCRIPTION
# TunnelDeck

TunnelDeck is a frontend UI to access the `nmcli` from within gaming mode in order to connect to a VPN. Upon install it builds a system extension from the `networkmanager-openvpn` package and overlays this within `/var/lib/extensions`. This adds support for OpenVPN connections without the need to disable SteamOS read only mode.

## Checklist:

- [x] I am the original author of this plugin.
- [x] I made my code efficient and readable.
- [x] I have verified that my plugin works properly on the latest versions of SteamOS and decky-loader.
- [x] I have verified that my plugin is unique and does not have the same functionality as another plugin on the store.
