### PR TITLE
Add AutoFlatpaks

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -68,3 +68,6 @@
 [submodule "plugins/SteamlessTimes"]
 	path = plugins/SteamlessTimes
 	url = https://github.com/EmuDeck/SteamlessTimes
+[submodule "plugins/decky-autoflatpaks"]
+	path = plugins/decky-autoflatpaks
+	url = https://github.com/jurassicplayer/decky-autoflatpaks.git


### PR DESCRIPTION
# AutoFlatpaks

A plugin to notify and automatically update flatpaks on your steamdeck console after an interval of time without DesktopMode. Requires root permissions.

## Checklist:

- [x] I am the original author of this plugin.
- [x] I made my code efficient and readable.
- [x] I have verified that my plugin works properly on the latest versions of SteamOS and decky-loader.
- [x] I have verified that my plugin is unique and does not have the same functionality as another plugin on the store.
