### PR TITLE
add FlatpakUpdater to decky plugin store

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -71,3 +71,6 @@
 [submodule "plugins/TunnelDeck"]
 	path = plugins/TunnelDeck
 	url = https://github.com/steve228uk/TunnelDeck
+[submodule "plugins/FkatpakUpdater"]
+	path = plugins/FlatpakUpdater
+	url = https://github.com/0xD34D/FlatpakUpdater


### PR DESCRIPTION
# FlatpakUpdater

Please include a summary of what the plugin does.

Checks for available flatpak updates and allows the user to apply all or choose individual flatpaks to update.

## Checklist:

- [x] I am the original author of this plugin.
- [X] I made my code efficient and readable.
- [X] I have verified that my plugin works properly on the latest versions of SteamOS and decky-loader.
- [X] I have verified that my plugin is unique and does not have the same functionality as another plugin on the store.
