### PR TITLE
Add KLang #2

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -77,3 +77,6 @@
 [submodule "plugins/decky-autoflatpaks"]
 	path = plugins/decky-autoflatpaks
 	url = https://github.com/jurassicplayer/decky-autoflatpaks.git
+[submodule "plugins/SDH-KLang"]
+	path = plugins/SDH-KLang
+	url = git@github.com:Loidbae/SDH-KLang.git


### PR DESCRIPTION
# Klang

(accidentally closed the [previous](https://github.com/SteamDeckHomebrew/decky-plugin-database/pull/132) pull request so here is a new one....)

Lets the user change layout and variant of external keyboards connected via bluetooth and/or usb. Currently there is no way to change the default layout of an external keyboard, for example I have a german keyboard which means my layout is "qwertz". Currently there is no other way to change it besides a workaround, which I implemented with this plugin.

Read more on the main page https://github.com/Loidbae/SDH-KLang

## Checklist:

- [x] I am the original author of this plugin.
- [x] I made my code efficient and readable.
- [x] I have verified that my plugin works properly on the latest versions of SteamOS and decky-loader.
- [x] I have verified that my plugin is unique and does not have the same functionality as another plugin on the store.
