### PR TITLE
Add moondeck plugin

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -77,3 +77,6 @@
 [submodule "plugins/decky-autoflatpaks"]
 	path = plugins/decky-autoflatpaks
 	url = https://github.com/jurassicplayer/decky-autoflatpaks.git
+[submodule "plugins/moondeck"]
+	path = plugins/moondeck
+	url = https://github.com/FrogTheFrog/moondeck


### PR DESCRIPTION
# MoonDeck

MoonDeck is an automation tool that will simplify launching your Steam games via the Moonlight client for streaming.

It requires an additional lightweight app to be installed on the host PC - [MoonDeck Buddy](https://github.com/FrogTheFrog/moondeck-buddy). Additional one-time setup instructions can be found within the settings page of the plugin itself.

## Checklist:

- [x] I am the original author of this plugin.
- [x] I made my code efficient and readable.
- [x] I have verified that my plugin works properly on the latest versions of SteamOS and decky-loader.
- [x] I have verified that my plugin is unique and does not have the same functionality as another plugin on the store.