### PR TITLE
Add SteamGridDB

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -83,3 +83,6 @@
 [submodule "plugins/moondeck"]
 	path = plugins/moondeck
 	url = https://github.com/FrogTheFrog/moondeck
+[submodule "plugins/decky-steamgriddb"]
+	path = plugins/decky-steamgriddb
+	url = https://github.com/SteamGridDB/decky-steamgriddb


### PR DESCRIPTION
# SteamGridDB

Easily browse and manage Steam artwork from SteamGridDB or your local files from within gaming mode.

## Checklist:

### Developer Checklist

- [x] I am the original author or an authorized maintainer of this plugin.
- [x] I abide by the licenses of the libraries I am utilizing, including attaching license notices where appropriate.

### Plugin Checklist

- [x] I have verified that my plugin works properly on the Stable and Beta update channels of SteamOS.
- [x] I have verified my plugin is unique or alternatively provides more/alternative functionality to a similar plugin already on the store.
