### PR TITLE
Added SDH-FreeGames

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -86,3 +86,6 @@
 [submodule "plugins/decky-steamgriddb"]
 	path = plugins/decky-steamgriddb
 	url = https://github.com/SteamGridDB/decky-steamgriddb
+[submodule "plugins/SDH-FreeGames"]
+	path = plugins/SDH-FreeGames
+	url = https://github.com/WerWolv/SDH-FreeGames


### PR DESCRIPTION
# SDH-FreeGames

This plugin simply shows today's free game on the Epic Game store and sends a daily toast notification telling you today's free game.

## Checklist:

### Developer Checklist

- [X] I am the original author or an authorized maintainer of this plugin.
- [X] I have abided by the licenses of the libraries I am utilizing, including attaching license notices where appropriate.

### Plugin Checklist

- [X] I have verified that my plugin works properly on the Stable and Beta update channels of SteamOS.
- [X] I have verified my plugin is unique or alternatively provides more/alternative functionality to a similair plugin already on the store.
<!-- The following section needs to be modified as yes/no answers by the plugin developer. -->

<!-- Ex: "**Yes/No**: ..." becomes "**Yes**: ..." -->

### Plugin Backend Checklist

- **No**: I am using a custom backend other than Python.
- **No**: I am using a tool or software from a 3rd party FOSS project that does not have it's dependencies [statically linked](https://en.wikipedia.org/wiki/Static_library).
- **No**: I am using a custom binary that has all of it's dependencies statically linked.

<!-- The following section is for testers and maintainers, please do not modify it. -->

## Testing

- [x] Tested on SteamOS Stable Update Channel.
- [x] Tested on SteamOS Beta Update Channel.
- [ ] Tested on SteamOS Preview Update Channel.
