### PR TITLE
add ShareDeck-y to store

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -86,3 +86,6 @@
 [submodule "plugins/decky-steamgriddb"]
 	path = plugins/decky-steamgriddb
 	url = https://github.com/SteamGridDB/decky-steamgriddb
+[submodule "plugins/sharedeck-y"]
+	path = plugins/sharedeck-y
+	url = https://github.com/davocarli/sharedeck-y


### PR DESCRIPTION
# ShareDeck-y

A plugin for browsing settings reports from https://sharedeck.games. Useful for users trying to figure out what settings to set on their Deck for different games..

## Checklist:

### Developer Checklist

- [x] I am the original author or an authorized maintainer of this plugin.
- [x] I have abided by the licenses of the libraries I am utilizing, including attaching license notices where appropriate.

### Plugin Checklist

- [x] I have verified that my plugin works properly on the Stable and Beta update channels of SteamOS.
- [x] I have verified my plugin is unique or alternatively provides more/alternative functionality to a similair plugin already on the store.

<!-- The following section needs to be modified as yes/no answers by the plugin developer. -->

<!-- Ex: "**Yes/No**: ..." becomes "**Yes**: ..." -->

### Plugin Backend Checklist

- **No**: I am using a custom backend other than Python.
- **No**: I am using a tool or software from a 3rd party FOSS project that does not have it's dependencies [statically linked](https://en.wikipedia.org/wiki/Static_library).
- **No**: I am using a custom binary that has all of it's dependencies statically linked.

<!-- The following section is for testers and maintainers, please do not modify it. -->

## Testing

- [x] Tested on SteamOS Stable Update Channel.
- [x] Tested on SteamOS Beta Update Channel.
- [x] Tested on SteamOS Preview Update Channel.
