### PR TITLE
Add ability to build plugins with a top-level Dockerfile

### DIFF
--- a/.github/workflows/build-plugins.yml
+++ b/.github/workflows/build-plugins.yml
@@ -94,7 +94,28 @@ jobs:
         unset $IFS
         echo "${sorted[@]}"
         echo edited_files=${sorted[@]} >> $GITHUB_OUTPUT
-    
+
+    - name: Build plugins with top-level Dockerfiles
+      id: build-top-level
+      run: |
+        pushd plugins
+        TO_BUILD_PLUGINS=$(find . -maxdepth 2 -name "Dockerfile" -exec dirname {} \;)
+        for plugin in $TO_BUILD_PLUGINS; do
+          echo $plugin
+
+          # Pretend to sanitize the directory name. Should improve this later
+          sane_plugin_name=$(basename $plugin)
+          output=/tmp/output-top-level/$sane_plugin_name
+
+          # Build plugin's top-level Dockerfile
+          docker build -f $plugin/Dockerfile -t $sane_plugin_name $plugin
+          docker run --rm -v $output:/output $sane_plugin_name
+
+          # Replace current plugin directory with built one from Docker
+          rm -r $plugin
+          cp -r $output .
+        done
+
     - name: Build plugin backends
       run: |
         IFS=' ' read -ra files <<< "${{ steps.list-files.outputs.edited_files }}"


### PR DESCRIPTION
This PR adds the ability for plugins to supply a top-level Dockerfile, which is expected to write to `/output` a directory matching Decky's expected filesystem structure, which is then processed along with other plugins normally.

This allows plugins to be more flexible in how they're structured and provides an overall less restrictive development cycle, allowing for developers to choose which tools and workflows to use, as long as their Dockerfile is able to translate them into Decky's format.

## Possible future improvements
1. Cache the docker images used by plugins. Not entirely sure how this is done, but finding all Dockerfiles in the plugins directory and extracting the image names should be sufficient?
2. Maybe force developers to pin their docker images to a specific tag, explicitly forbidding the all-too-common `latest` tag. This should prevent deployment breaking after breaking changes in images used by plugins.
3. Properly sanitize the `sane_plugin_name` variable. This will currently break if the plugin's directory name contains characters that are invalid names for Docker image tags. It's an edge case but it might be worth addressing depending on how simple the solution is.

## Notes
1. Line 116 uses `cp` instead of `mv` due to permission nonsense. The GitHub Actions user doesn't seem to have permission to remove the output directory, probably because Docker runs as root. It's not a big deal but it felt worth mentioning anyways
2. Currently `Dockerfile`s are expected to place the artifacts in `/output`, since that's the directoy that's mounted to the host. If there's a convention for this sort of thing, or a proper Docker mechanic for outputting artifacts to the host, please let me know.

## Testing
Since there are not yet any plugins that use this mechanism, for testing I created a directory in `plugins` named `test-plugin` with a `Dockerfile` that just `git clone`s an existing plugin (in my case it was Fantastic) into `/output`.

- [ ] Tested on SteamOS Stable Update Channel.
- [ ] Tested on SteamOS Beta Update Channel.
- [ ] Tested on SteamOS Preview Update Channel.
