### PR TITLE
Parallelize building and uploading of plugins

### DIFF
--- a/.github/workflows/build-plugin-testing.yml
+++ b/.github/workflows/build-plugin-testing.yml
@@ -1,0 +1,231 @@
+name: Build Plugins for testing
+
+on:
+  pull_request:
+    branches: ['*']
+  workflow_dispatch:
+    inputs:
+      build_all:
+        type: boolean
+        default: false
+        description: Build all plugins, not just the ones that are detected as changing
+
+jobs:
+  find_plugins:
+    outputs:
+      plugins: ${{ steps.find_plugins.outputs.plugins }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        if: ${{ !env.ACT }}
+        uses: actions/checkout@8230315d06ad95c617244d2f265d237a1682d445
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Find plugins to be built
+        id: find_plugins
+        env:
+          isPr: ${{ github.event_name == 'pull_request' }}
+          buildAll: ${{ inputs.build_all }}
+        run: |
+          workflow_changed=$(git diff --name-only --submodule=diff -- .github/workflows/build-plugins.yml)
+          if [[ $workflow_changed || $buildAll == "true" ]]; then
+            # Workflow changed. Build everything to be safe
+            PLUGINS=$(find ./plugins -mindepth 1 -maxdepth 1 -type d -print0 | xargs -0 -n1 -- basename | jq -Rsc 'split("\n")[:-1]')
+          else
+            if [[ $isPr == "true" ]]; then
+              echo "PR detected. beep boop"
+              git fetch --no-tags --prune --depth=1 origin +refs/heads/*:refs/remotes/origin/*
+              # Diff with the ref of the target branch
+              REF=origin/${{ github.base_ref }}
+            else
+              echo "This is probably a push to main or something"
+              # Diff with previous commit
+              REF=(${{ github.ref }} ${{ github.event.before }})
+            fi
+
+            PLUGINS=$(git diff --name-only --submodule=diff ${REF[@]} -- plugins | xargs -0 -n1 -- basename | jq -Rsc 'split("\n")[:-2]')
+          fi
+
+          echo "plugins=$PLUGINS" >> $GITHUB_OUTPUT
+
+  build:
+    name: Build plugin
+    runs-on: ubuntu-latest
+    needs:
+      - find_plugins
+    if: ${{ needs.find_plugins.outputs.plugins != '[]' }}
+    continue-on-error: true
+    strategy:
+      matrix:
+        plugin: ${{ fromJSON(needs.find_plugins.outputs.plugins) }}
+    outputs:
+      name: ${{ steps.set_name.outputs.name }}
+
+    steps:
+    - name: Checkout
+      if: ${{ !env.ACT }}
+      uses: actions/checkout@8230315d06ad95c617244d2f265d237a1682d445
+      with:
+        ref: ${{ github.event.pull_request.head.sha || github.sha }}
+        fetch-depth: 0
+        token: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Checkout plugin submodule
+      run: |
+        git submodule update --init --depth 1 plugins/${{ matrix.plugin }}
+
+    - name: Pull frontend builder image
+      run: docker pull ghcr.io/steamdeckhomebrew/builder:latest
+
+    - name: Pull backend builder image
+      run: docker pull ghcr.io/steamdeckhomebrew/holo-base:latest
+
+    - name: Build plugin backend
+      run: |
+        plugin=${{ matrix.plugin }}
+        pushd plugins
+        pushd $plugin
+        echo "Detecting backend for plugin $plugin"
+        dockerfile_exists="false"
+        entrypoint_exists="false"
+        docker_name="backend-${plugin,,}"
+        # [ -d $PWD/backend ] && echo "$(ls -lla $PWD/backend | grep Dockerfile)"
+        [ -f $PWD/backend/Dockerfile ] && dockerfile_exists=true
+        [ -f $PWD/backend/entrypoint.sh ] && entrypoint_exists=true
+        # check for Dockerfile
+        if [[ "$dockerfile_exists" == "true" ]]; then
+          echo "Grabbing provided dockerfile."
+          echo "Building provided Dockerfile."
+          docker build -f $PWD/backend/Dockerfile -t "$docker_name" .
+          mkdir -p /tmp/output/$plugin/backend/out
+          # check entrypoint script exists
+          if [[ "$entrypoint_exists" == "true" ]]; then
+            echo "Running docker image "$docker_name" with provided entrypoint script."
+            docker run --rm -i -v $PWD/backend:/backend -v /tmp/output/$plugin/backend/out:/backend/out --entrypoint /backend/entrypoint.sh "$docker_name"
+            mkdir -p /tmp/output/$plugin/bin
+            cp -r /tmp/output/$plugin/backend/out/. /tmp/output/$plugin/bin
+          else
+            echo "Running docker image "$docker_name" with entrypoint script specified in Dockerfile."
+            docker run --rm -i -v $PWD/backend:/backend -v /tmp/output/$plugin/backend/out:/backend/out "$docker_name"
+            mkdir -p /tmp/output/$plugin/bin
+            cp -r /tmp/output/$plugin/backend/out/. /tmp/output/$plugin/bin
+          fi
+          docker image rm "$docker_name"
+          echo "Built $plugin backend"
+        # Dockerfile doesn't exist but entrypoint script does, run w/ default image
+        elif [[ "$dockerfile_exists" == "false" && "$entrypoint_exists" == "true" ]]; then
+          echo "Grabbing default docker image and using provided entrypoint script."
+          docker run --rm -i -v $PWD/backend:/backend -v /tmp/output/$plugin/backend/out:/backend/out ghcr.io/steamdeckhomebrew/holo-base:latest
+          mkdir -p /tmp/output/$plugin/bin
+          cp /tmp/output/$plugin/backend/out/. /tmp/output/$plugin/bin
+          echo "Built $plugin backend"
+        else
+          echo "Plugin $plugin does not have a backend"
+        fi
+        # ls -lla /tmp/output/$plugin
+        popd
+        popd
+
+    - name: Build plugin frontend
+      run: |
+        shopt -s extglob
+        pushd plugins
+        plugin=${{ matrix.plugin }}
+        pushd $plugin
+        docker run --rm -i -v $PWD:/plugin -v /tmp/output/$plugin:/out ghcr.io/steamdeckhomebrew/builder:latest
+        echo Built $plugin frontend
+        ls -lla /tmp/output/$plugin
+        cd /tmp/output/$plugin
+        popd
+        popd
+
+    - name: Zip Plugins
+      run: |
+        shopt -s dotglob
+        mkdir -p /tmp/zips/
+        mkdir -p /tmp/output/
+        redtext=$'\e[1;31m'
+        end=$'\e[0m'
+        pushd /tmp/output
+        plugin=$(basename ${{ matrix.plugin }})
+        zipname=/tmp/$plugin.zip
+        echo $plugin
+
+        # Names of the optional files (the license can either be called license or license.md, not both)
+        # (head is there to take the first file, because we're assuming there's only a single license file)
+        license="$(find $plugin -maxdepth 1 -type f \( -iname "license" -o -iname "license.md" \) -printf '%P\n' | head -n 1)"
+        readme="$(find $plugin -maxdepth 1 -type f -iname 'readme.md' -printf '%P\n')"
+        haspython="$(find $plugin -maxdepth 1 -type f -name '*.py' -printf '%P\n')"
+        # Check if plugin has a bin folder, if so, add "bin" and it's contents to root dir
+        hasbin="$(find $plugin -maxdepth 1 -type d -name 'bin' -printf '%P\n')"
+        # Check if plugin has a defaults folder, if so, add "default" contents to root dir
+        hasdefaults="$(find $plugin -maxdepth 1 -type d -name 'defaults' -printf '%P\n')"
+        if [[ "${{ secrets.STORE_ENV }}" == "testing" ]]; then
+          long_sha="${{ github.event.pull_request.head.sha || github.sha }}"
+          sha=$(echo $long_sha | cut -c1-7)
+          cat $plugin/package.json | jq --arg jqsha "$sha" '.version |= . + "-" + $jqsha' | sudo tee $plugin/$sha-package.json
+          sudo mv $plugin/$sha-package.json $plugin/package.json
+        fi
+        # Add required plugin files (and directory) to zip file
+        echo "$plugin/dist $plugin/plugin.json $plugin/package.json"
+        zip -r $zipname "$plugin/dist" "$plugin/plugin.json" "$plugin/package.json"
+        if [ ! -z "$hasbin" ]; then
+          echo "$plugin/bin"
+          zip -r $zipname "$plugin/bin"
+        fi
+
+        if [ ! -z "$haspython" ]; then
+          echo "$plugin/*.py"
+          find $plugin -maxdepth 1 -type f -name '*.py' -exec zip -r $zipname {} \;
+        fi
+
+        if [ ! -z "$hasdefaults" ]; then
+          export workingdir=$PWD
+          cd $plugin/defaults
+          export plugin="$plugin"
+          export zipname="$zipname"
+          if [ ! -f "defaults.txt" ]; then
+            find . -mindepth 1 -type d,f -name '*' -exec bash -c '
+              for object do
+                outdir="/tmp/output"
+                name="$(basename $object)"
+                # echo "object = $object, name = $name"
+                if [ -e "$object" ]; then
+                  sudo mv "$object" $outdir/$plugin/$name
+                  moved="$?"
+                  # echo "moved = $moved"
+                  pushd $workingdir
+                  if [ "$moved" = "0" ]; then
+                    zip -r $zipname $plugin/$name
+                  fi
+                  popd
+                fi
+              done
+            ' find-sh {} + ;
+          else
+            if [[ ! "$plugin" =~ "plugin-template" ]]; then
+              printf "${red}defaults.txt found in defaults folder, please remove either defaults.txt or the defaults folder.${end}\n"
+            else
+              printf "plugin template, allowing defaults.txt\n"
+            fi
+          fi
+          cd "$workingdir"
+        fi
+
+        # Check if other files exist, and if they do, add them
+        echo "license:$plugin/$license readme:$plugin/$readme"
+        if [ ! -z "$license" ]; then
+          zip -r $zipname "$plugin/$license"
+        fi
+        if [ ! -z "$readme" ]; then
+          zip -r $zipname "$plugin/$readme"
+        fi
+        popd
+
+    - name: Upload plugin artifact
+      uses: actions/upload-artifact@v3
+      with:
+        name: ${{ matrix.plugin }}
+        path: /tmp/${{ matrix.plugin }}.zip

--- a/.github/workflows/build-plugins.yml
+++ b/.github/workflows/build-plugins.yml
@@ -212,10 +212,11 @@ jobs:
                     sudo mv "$object" $outdir/$plugin/$name
                     moved="$?"
                     # echo "moved = $moved"
-                    cd $workingdir
+                    pushd $workingdir
                     if [ "$moved" = "0" ]; then
                       zip -r $zipname $plugin/$name
                     fi
+                    popd
                   fi
                 done
               ' find-sh {} + ;

--- a/.github/workflows/build-plugins.yml
+++ b/.github/workflows/build-plugins.yml
@@ -1,4 +1,4 @@
-name: Build Plugins in Parallel
+name: Build plugins
 
 on:
   push:
@@ -9,7 +9,7 @@ on:
     paths:
       - "plugins/**"
       - ".github/workflows/build-plugins.yml"
-  pull_request_target:
+  pull_request:
     branches: ['*']
   workflow_dispatch:
     inputs:
@@ -32,7 +32,7 @@ jobs:
         if: ${{ !env.ACT }}
         uses: actions/checkout@8230315d06ad95c617244d2f265d237a1682d445
         with:
-          fetch-depth: 9
+          fetch-depth: 0
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Find plugins to be built
@@ -47,14 +47,17 @@ jobs:
             PLUGINS=$(find ./plugins -mindepth 1 -maxdepth 1 -type d -print0 | xargs -0 -n1 -- basename | jq -Rsc 'split("\n")[:-1]')
           else
             if [[ $isPr == "true" ]]; then
+              echo "PR detected. beep boop"
+              git fetch --no-tags --prune --depth=1 origin +refs/heads/*:refs/remotes/origin/*
               # Diff with the ref of the target branch
-              REF=${{ github.base_ref }}
+              REF=origin/${{ github.base_ref }}
             else
+              echo "This is probably a push to main or something"
               # Diff with previous commit
-              REF=(${{ github.event.base_ref }} ${{ github.event.before }})
+              REF=(${{ github.ref }} ${{ github.event.before }})
             fi
 
-            PLUGINS=$(git diff --name-only --submodule=diff $REF -- plugins | xargs -0 -n1 -- basename | jq -Rsc 'split("\n")[:-2]')
+            PLUGINS=$(git diff --name-only --submodule=diff ${REF[@]} -- plugins | xargs -0 -n1 -- basename | jq -Rsc 'split("\n")[:-2]')
           fi
 
           echo "plugins=$PLUGINS" >> $GITHUB_OUTPUT
@@ -238,48 +241,3 @@ jobs:
       with:
         name: ${{ matrix.plugin }}
         path: /tmp/${{ matrix.plugin }}.zip
-
-  upload:
-    runs-on: ubuntu-latest
-    needs:
-      - find_plugins
-      - build
-    if: ${{ needs.find_plugins.outputs.plugins != '[]' && inputs.upload }}
-    environment:
-      name: ${{ (github.ref == 'refs/heads/main' && (github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && github.event.inputs.upload))) && 'env' || 'testing_env' }}
-    strategy:
-      matrix:
-        plugin: ${{ fromJSON(needs.find_plugins.outputs.plugins) }}
-    steps:
-    - uses: actions/download-artifact@v3
-      with:
-        name: ${{ matrix.plugin }}
-
-    - name: Upload plugin to store
-      if: ${{ !env.ACT }}
-      id: upload-plugins
-      run: |
-        shopt -s dotglob
-        plugin=${{ matrix.plugin }}
-        zipname=$(basename ${plugin}).zip
-
-        metadata=$(unzip -p $zipname $plugin/plugin.json)
-        packagejson=$(unzip -p $zipname $plugin/package.json)
-
-        donotupload=$(jq -r '.publish | any(.tags[] == "dnu"; .)' <<< $metadata)
-        if [[ "$donotupload" == "false" ]]; then
-          curl -X POST \
-          -H "Authorization: ${SUBMIT_AUTH_KEY}" \
-          -F "name=$(jq -r '.name' <<< $metadata)" \
-          -F "author=$(jq -r '.author' <<< $metadata)" \
-          -F "description=$(jq -r '.publish.description' <<< $metadata)" \
-          -F "tags=$(jq -r '.publish.tags|join(",")' <<< $metadata)" \
-          -F "version_name=$(jq -r '.version' <<< $packagejson)" \
-          -F "image=$(jq -r '.publish.image' <<< $metadata)" \
-          -F "file=@${zipname}" ${STORE_URL}/__submit
-        else
-          echo "Plugin is designated as 'do not upload', likely a template or CI demonstration."
-        fi
-      env:
-        SUBMIT_AUTH_KEY: ${{ secrets.SUBMIT_AUTH_KEY }}
-        STORE_URL: ${{ secrets.STORE_URL }}

--- a/.github/workflows/build-plugins.yml
+++ b/.github/workflows/build-plugins.yml
@@ -42,6 +42,7 @@ jobs:
         files: |
           plugins/*
           .github/workflows/build-plugins.yml
+
     - name: Cache Docker images
       if: ${{ !env.ACT }}
       uses: satackey/action-docker-layer-caching@46d2c640b1d8ef50d185452ad6fb324e6bd1d052
@@ -67,6 +68,7 @@ jobs:
     - name: Log out of GitHub Container Registry
       run: |
         docker logout ghcr.io
+
     - name: Detect edited files/plugins
       id: list-files
       run: |
@@ -140,6 +142,7 @@ jobs:
           popd
         done
         popd
+
     - name: Build plugin frontends
       run: |
         IFS=' ' read -ra files <<< "${{ steps.list-files.outputs.edited_files }}"
@@ -165,6 +168,7 @@ jobs:
           plugin=$(basename $abs_plugin)
           zipname=/tmp/zips/$(basename ${plugin}).zip
           echo $plugin
+
           # Names of the optional files (the license can either be called license or license.md, not both)
           # (head is there to take the first file, because we're assuming there's only a single license file)
           license="$(find $plugin -maxdepth 1 -type f \( -iname "license" -o -iname "license.md" \) -printf '%P\n' | head -n 1)"
@@ -187,10 +191,12 @@ jobs:
             echo "$plugin/bin"
             zip -r $zipname "$plugin/bin"
           fi
+
           if [ ! -z "$haspython" ]; then
             echo "$plugin/*.py"
             find $plugin -maxdepth 1 -type f -name '*.py' -exec zip -r $zipname {} \;
           fi
+
           if [ ! -z "$hasdefaults" ]; then
             export workingdir=$PWD
             cd $plugin/defaults
@@ -223,6 +229,7 @@ jobs:
             fi
             cd "$workingdir"
           fi
+
           # Check if other files exist, and if they do, add them
           echo "license:$plugin/$license readme:$plugin/$readme"
           if [ ! -z "$license" ]; then
@@ -233,6 +240,7 @@ jobs:
           fi
         done
         popd
+
     - name: Upload Artifacts to Github
       if: ${{ !env.ACT }}
       uses: actions/upload-artifact@3cea5372237819ed00197afe530f5a7ea3e805c8

--- a/.github/workflows/build-plugins.yml
+++ b/.github/workflows/build-plugins.yml
@@ -1,79 +1,27 @@
-name: Build plugins
+name: Build Plugins
 
 on:
   push:
     branches:
       - main
       - backend-builder
-      - parallelize-ci
     paths:
       - "plugins/**"
       - ".github/workflows/build-plugins.yml"
-  pull_request:
+  pull_request_target:
     branches: ['*']
   workflow_dispatch:
     inputs:
-      build_all:
-        type: boolean
-        default: false
-        description: Build all plugins, not just the ones that are detected as changing
       upload:
         type: boolean
-        default: false
-        description: Upload the detected plugins to the store
+        description: Re-upload the plugins to the store
 
 jobs:
-  find_plugins:
-    outputs:
-      plugins: ${{ steps.find_plugins.outputs.plugins }}
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        if: ${{ !env.ACT }}
-        uses: actions/checkout@8230315d06ad95c617244d2f265d237a1682d445
-        with:
-          fetch-depth: 0
-          token: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Find plugins to be built
-        id: find_plugins
-        env:
-          isPr: ${{ github.event_name == 'pull_request' }}
-          buildAll: ${{ inputs.build_all }}
-        run: |
-          workflow_changed=$(git diff --name-only --submodule=diff $REF -- .github/workflows/build-plugins.yml)
-          if [[ $workflow_changed || $buildAll == "true" ]]; then
-            # Workflow changed. Build everything to be safe
-            PLUGINS=$(find ./plugins -mindepth 1 -maxdepth 1 -type d -print0 | xargs -0 -n1 -- basename | jq -Rsc 'split("\n")[:-1]')
-          else
-            if [[ $isPr == "true" ]]; then
-              echo "PR detected. beep boop"
-              git fetch --no-tags --prune --depth=1 origin +refs/heads/*:refs/remotes/origin/*
-              # Diff with the ref of the target branch
-              REF=origin/${{ github.base_ref }}
-            else
-              echo "This is probably a push to main or something"
-              # Diff with previous commit
-              REF=(${{ github.ref }} ${{ github.event.before }})
-            fi
-
-            PLUGINS=$(git diff --name-only --submodule=diff ${REF[@]} -- plugins | xargs -0 -n1 -- basename | jq -Rsc 'split("\n")[:-2]')
-          fi
-
-          echo "plugins=$PLUGINS" >> $GITHUB_OUTPUT
-
   build:
-    name: Build plugin
+    name: Build updated plugins
     runs-on: ubuntu-latest
-    needs:
-      - find_plugins
-    if: ${{ needs.find_plugins.outputs.plugins != '[]' }}
-    continue-on-error: true
-    strategy:
-      matrix:
-        plugin: ${{ fromJSON(needs.find_plugins.outputs.plugins) }}
-    outputs:
-      name: ${{ steps.set_name.outputs.name }}
+    environment:
+      name: ${{ (github.ref == 'refs/heads/main' && (github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && github.event.inputs.upload))) && 'env' || 'testing_env' }}
 
     steps:
     - name: Checkout
@@ -82,11 +30,33 @@ jobs:
       with:
         ref: ${{ github.event.pull_request.head.sha || github.sha }}
         fetch-depth: 0
+        submodules: "recursive"
         token: ${{ secrets.GITHUB_TOKEN }}
 
-    - name: Checkout plugin submodule
+    - name: Get changed files
+      id: changed-files
+      uses: tj-actions/changed-files@210f4edecfff9e901066850eb306b947d09092bc
+      with:
+        sha: ${{ github.event.pull_request.head.sha || github.sha }}
+        separator: ","
+        files: |
+          plugins/*
+          .github/workflows/build-plugins.yml
+    - name: Cache Docker images
+      if: ${{ !env.ACT }}
+      uses: satackey/action-docker-layer-caching@46d2c640b1d8ef50d185452ad6fb324e6bd1d052
+
+    - name: Login to GitHub Container Registry
       run: |
-        git submodule update --init --depth 1 plugins/${{ matrix.plugin }}
+        echo $GITHUB_TOKEN | docker login ghcr.io -u SteamDeckHomebrew --password-stdin
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Wait for other runs to complete
+      if: ${{ !env.ACT }}
+      uses: pau1ocampos/turnstyle@17e7c2e349edeb2fc92d15e99f389c6011e02956
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Pull frontend builder image
       run: docker pull ghcr.io/steamdeckhomebrew/builder:latest
@@ -94,63 +64,93 @@ jobs:
     - name: Pull backend builder image
       run: docker pull ghcr.io/steamdeckhomebrew/holo-base:latest
 
-    - name: Build plugin backend
+    - name: Log out of GitHub Container Registry
       run: |
-        plugin=${{ matrix.plugin }}
+        docker logout ghcr.io
+    - name: Detect edited files/plugins
+      id: list-files
+      run: |
         pushd plugins
-        pushd $plugin
-        echo "Detecting backend for plugin $plugin"
-        dockerfile_exists="false"
-        entrypoint_exists="false"
-        docker_name="backend-${plugin,,}"
-        # [ -d $PWD/backend ] && echo "$(ls -lla $PWD/backend | grep Dockerfile)"
-        [ -f $PWD/backend/Dockerfile ] && dockerfile_exists=true
-        [ -f $PWD/backend/entrypoint.sh ] && entrypoint_exists=true
-        # check for Dockerfile
-        if [[ "$dockerfile_exists" == "true" ]]; then
-          echo "Grabbing provided dockerfile."
-          echo "Building provided Dockerfile."
-          docker build -f $PWD/backend/Dockerfile -t "$docker_name" .
-          mkdir -p /tmp/output/$plugin/backend/out
-          # check entrypoint script exists
-          if [[ "$entrypoint_exists" == "true" ]]; then
-            echo "Running docker image "$docker_name" with provided entrypoint script."
-            docker run --rm -i -v $PWD/backend:/backend -v /tmp/output/$plugin/backend/out:/backend/out --entrypoint /backend/entrypoint.sh "$docker_name"
-            mkdir -p /tmp/output/$plugin/bin
-            cp -r /tmp/output/$plugin/backend/out/. /tmp/output/$plugin/bin
-          else
-            echo "Running docker image "$docker_name" with entrypoint script specified in Dockerfile."
-            docker run --rm -i -v $PWD/backend:/backend -v /tmp/output/$plugin/backend/out:/backend/out "$docker_name"
-            mkdir -p /tmp/output/$plugin/bin
-            cp -r /tmp/output/$plugin/backend/out/. /tmp/output/$plugin/bin
-          fi
-          docker image rm "$docker_name"
-          echo "Built $plugin backend"
-        # Dockerfile doesn't exist but entrypoint script does, run w/ default image
-        elif [[ "$dockerfile_exists" == "false" && "$entrypoint_exists" == "true" ]]; then
-          echo "Grabbing default docker image and using provided entrypoint script."
-          docker run --rm -i -v $PWD/backend:/backend -v /tmp/output/$plugin/backend/out:/backend/out ghcr.io/steamdeckhomebrew/holo-base:latest
-          mkdir -p /tmp/output/$plugin/bin
-          cp /tmp/output/$plugin/backend/out/. /tmp/output/$plugin/bin
-          echo "Built $plugin backend"
+        files=()
+        if [[ "${{ steps.changed-files.outputs.all_changed_files }}" == *".github/workflows/build-plugins.yml"* || "${{ (github.event_name == 'workflow_dispatch' && github.event.inputs.upload) && 'true' }}" == "true" ]];
+        then
+          echo "Rebuilding all plugins due to workflow edit"
+          for file in ./plugins/*; do
+            files+=($(cut -d/ -f3 <<< $file))
+          done
         else
-          echo "Plugin $plugin does not have a backend"
+          rest="${{ steps.changed-files.outputs.all_changed_files }}"
+          while [ -n "$rest" ] ; do
+            str=${rest%%,*}
+            [ "$rest" = "${rest/,/}" ] && rest= || rest=${rest#*,}
+            files+=($(cut -d/ -f2 <<< $str))
+          done <<< "$files"
+          printf "%s\n" "${files[@]}" | sort -u
         fi
-        # ls -lla /tmp/output/$plugin
         popd
-        popd
+        IFS=$'\n' sorted=($(sort -u <<<"${files[@]}"))
+        unset $IFS
+        echo "${sorted[@]}"
+        echo edited_files=${sorted[@]} >> $GITHUB_OUTPUT
 
-    - name: Build plugin frontend
+    - name: Build plugin backends
       run: |
-        shopt -s extglob
+        IFS=' ' read -ra files <<< "${{ steps.list-files.outputs.edited_files }}"
         pushd plugins
-        plugin=${{ matrix.plugin }}
-        pushd $plugin
-        docker run --rm -i -v $PWD:/plugin -v /tmp/output/$plugin:/out ghcr.io/steamdeckhomebrew/builder:latest
-        echo Built $plugin frontend
-        ls -lla /tmp/output/$plugin
-        cd /tmp/output/$plugin
+        for plugin in $(printf "%s\n" "${files[@]}" | sort -u); do
+          pushd $plugin
+          echo "Detecting backend for plugin $plugin"
+          dockerfile_exists="false"
+          entrypoint_exists="false"
+          docker_name="backend-${plugin,,}"
+          # [ -d $PWD/backend ] && echo "$(ls -lla $PWD/backend | grep Dockerfile)"
+          [ -f $PWD/backend/Dockerfile ] && dockerfile_exists=true
+          [ -f $PWD/backend/entrypoint.sh ] && entrypoint_exists=true
+          # check for Dockerfile
+          if [[ "$dockerfile_exists" == "true" ]]; then
+            echo "Grabbing provided dockerfile."
+            echo "Building provided Dockerfile."
+            docker build -f $PWD/backend/Dockerfile -t "$docker_name" .
+            mkdir -p /tmp/output/$plugin/backend/out
+            # check entrypoint script exists
+            if [[ "$entrypoint_exists" == "true" ]]; then
+              echo "Running docker image "$docker_name" with provided entrypoint script."
+              docker run --rm -i -v $PWD/backend:/backend -v /tmp/output/$plugin/backend/out:/backend/out --entrypoint /backend/entrypoint.sh "$docker_name"
+              mkdir -p /tmp/output/$plugin/bin
+              cp -r /tmp/output/$plugin/backend/out/. /tmp/output/$plugin/bin
+            else
+              echo "Running docker image "$docker_name" with entrypoint script specified in Dockerfile."
+              docker run --rm -i -v $PWD/backend:/backend -v /tmp/output/$plugin/backend/out:/backend/out "$docker_name"
+              mkdir -p /tmp/output/$plugin/bin
+              cp -r /tmp/output/$plugin/backend/out/. /tmp/output/$plugin/bin
+            fi
+            docker image rm "$docker_name"
+            echo "Built $plugin backend"
+          # Dockerfile doesn't exist but entrypoint script does, run w/ default image
+          elif [[ "$dockerfile_exists" == "false" && "$entrypoint_exists" == "true" ]]; then
+            echo "Grabbing default docker image and using provided entrypoint script."
+            docker run --rm -i -v $PWD/backend:/backend -v /tmp/output/$plugin/backend/out:/backend/out ghcr.io/steamdeckhomebrew/holo-base:latest
+            mkdir -p /tmp/output/$plugin/bin
+            cp /tmp/output/$plugin/backend/out/. /tmp/output/$plugin/bin
+            echo "Built $plugin backend"
+          else
+            echo "Plugin $plugin does not have a backend"
+          fi
+          # ls -lla /tmp/output/$plugin
+          popd
+        done
         popd
+    - name: Build plugin frontends
+      run: |
+        IFS=' ' read -ra files <<< "${{ steps.list-files.outputs.edited_files }}"
+        pushd plugins
+        for plugin in $(printf "%s\n" "${files[@]}" | sort -u); do
+          pushd $plugin
+          docker run --rm -i -v $PWD:/plugin -v /tmp/output/$plugin:/out ghcr.io/steamdeckhomebrew/builder:latest
+          echo Built $plugin frontend
+          ls -lla /tmp/output/$plugin
+          popd
+        done
         popd
 
     - name: Zip Plugins
@@ -161,83 +161,101 @@ jobs:
         redtext=$'\e[1;31m'
         end=$'\e[0m'
         pushd /tmp/output
-        plugin=$(basename ${{ matrix.plugin }})
-        zipname=/tmp/$plugin.zip
-        echo $plugin
-
-        # Names of the optional files (the license can either be called license or license.md, not both)
-        # (head is there to take the first file, because we're assuming there's only a single license file)
-        license="$(find $plugin -maxdepth 1 -type f \( -iname "license" -o -iname "license.md" \) -printf '%P\n' | head -n 1)"
-        readme="$(find $plugin -maxdepth 1 -type f -iname 'readme.md' -printf '%P\n')"
-        haspython="$(find $plugin -maxdepth 1 -type f -name '*.py' -printf '%P\n')"
-        # Check if plugin has a bin folder, if so, add "bin" and it's contents to root dir
-        hasbin="$(find $plugin -maxdepth 1 -type d -name 'bin' -printf '%P\n')"
-        # Check if plugin has a defaults folder, if so, add "default" contents to root dir
-        hasdefaults="$(find $plugin -maxdepth 1 -type d -name 'defaults' -printf '%P\n')"
-        if [[ "${{ secrets.STORE_ENV }}" == "testing" ]]; then
-          long_sha="${{ github.event.pull_request.head.sha || github.sha }}"
-          sha=$(echo $long_sha | cut -c1-7)
-          cat $plugin/package.json | jq --arg jqsha "$sha" '.version |= . + "-" + $jqsha' | sudo tee $plugin/$sha-package.json
-          sudo mv $plugin/$sha-package.json $plugin/package.json
-        fi
-        # Add required plugin files (and directory) to zip file
-        echo "$plugin/dist $plugin/plugin.json $plugin/package.json"
-        zip -r $zipname "$plugin/dist" "$plugin/plugin.json" "$plugin/package.json"
-        if [ ! -z "$hasbin" ]; then
-          echo "$plugin/bin"
-          zip -r $zipname "$plugin/bin"
-        fi
-
-        if [ ! -z "$haspython" ]; then
-          echo "$plugin/*.py"
-          find $plugin -maxdepth 1 -type f -name '*.py' -exec zip -r $zipname {} \;
-        fi
-
-        if [ ! -z "$hasdefaults" ]; then
-          export workingdir=$PWD
-          cd $plugin/defaults
-          export plugin="$plugin"
-          export zipname="$zipname"
-          if [ ! -f "defaults.txt" ]; then
-            find . -mindepth 1 -type d,f -name '*' -exec bash -c '
-              for object do
-                outdir="/tmp/output"
-                name="$(basename $object)"
-                # echo "object = $object, name = $name"
-                if [ -e "$object" ]; then
-                  sudo mv "$object" $outdir/$plugin/$name
-                  moved="$?"
-                  # echo "moved = $moved"
-                  pushd $workingdir
-                  if [ "$moved" = "0" ]; then
-                    zip -r $zipname $plugin/$name
-                  fi
-                  popd
-                fi
-              done
-            ' find-sh {} + ;
-          else
-            if [[ ! "$plugin" =~ "plugin-template" ]]; then
-              printf "${red}defaults.txt found in defaults folder, please remove either defaults.txt or the defaults folder.${end}\n"
-            else
-              printf "plugin template, allowing defaults.txt\n"
-            fi
+        for abs_plugin in /tmp/output/*; do
+          plugin=$(basename $abs_plugin)
+          zipname=/tmp/zips/$(basename ${plugin}).zip
+          echo $plugin
+          # Names of the optional files (the license can either be called license or license.md, not both)
+          # (head is there to take the first file, because we're assuming there's only a single license file)
+          license="$(find $plugin -maxdepth 1 -type f \( -iname "license" -o -iname "license.md" \) -printf '%P\n' | head -n 1)"
+          readme="$(find $plugin -maxdepth 1 -type f -iname 'readme.md' -printf '%P\n')"
+          haspython="$(find $plugin -maxdepth 1 -type f -name '*.py' -printf '%P\n')"
+          # Check if plugin has a bin folder, if so, add "bin" and it's contents to root dir
+          hasbin="$(find $plugin -maxdepth 1 -type d -name 'bin' -printf '%P\n')"
+          # Check if plugin has a defaults folder, if so, add "default" contents to root dir
+          hasdefaults="$(find $plugin -maxdepth 1 -type d -name 'defaults' -printf '%P\n')"
+          if [[ "${{ secrets.STORE_ENV }}" == "testing" ]]; then
+            long_sha="${{ github.event.pull_request.head.sha || github.sha }}"
+            sha=$(echo $long_sha | cut -c1-7)
+            cat $plugin/package.json | jq --arg jqsha "$sha" '.version |= . + "-" + $jqsha' | sudo tee $plugin/$sha-package.json
+            sudo mv $plugin/$sha-package.json $plugin/package.json
           fi
-          cd "$workingdir"
-        fi
-
-        # Check if other files exist, and if they do, add them
-        echo "license:$plugin/$license readme:$plugin/$readme"
-        if [ ! -z "$license" ]; then
-          zip -r $zipname "$plugin/$license"
-        fi
-        if [ ! -z "$readme" ]; then
-          zip -r $zipname "$plugin/$readme"
-        fi
+          # Add required plugin files (and directory) to zip file
+          echo "$plugin/dist $plugin/plugin.json $plugin/package.json"
+          zip -r $zipname "$plugin/dist" "$plugin/plugin.json" "$plugin/package.json"
+          if [ ! -z "$hasbin" ]; then
+            echo "$plugin/bin"
+            zip -r $zipname "$plugin/bin"
+          fi
+          if [ ! -z "$haspython" ]; then
+            echo "$plugin/*.py"
+            find $plugin -maxdepth 1 -type f -name '*.py' -exec zip -r $zipname {} \;
+          fi
+          if [ ! -z "$hasdefaults" ]; then
+            export workingdir=$PWD
+            cd $plugin/defaults
+            export plugin="$plugin"
+            export zipname="$zipname"
+            if [ ! -f "defaults.txt" ]; then
+              find . -mindepth 1 -type d,f -name '*' -exec bash -c '
+                for object do
+                  outdir="/tmp/output"
+                  name="$(basename $object)"
+                  # echo "object = $object, name = $name"
+                  if [ -e "$object" ]; then
+                    sudo mv "$object" $outdir/$plugin/$name
+                    moved="$?"
+                    # echo "moved = $moved"
+                    pushd $workingdir
+                    if [ "$moved" = "0" ]; then
+                      zip -r $zipname $plugin/$name
+                    fi
+                    popd
+                  fi
+                done
+              ' find-sh {} + ;
+            else
+              if [[ ! "$plugin" =~ "plugin-template" ]]; then
+                printf "${red}defaults.txt found in defaults folder, please remove either defaults.txt or the defaults folder.${end}\n"
+              else
+                printf "plugin template, allowing defaults.txt\n"
+              fi
+            fi
+            cd "$workingdir"
+          fi
+          # Check if other files exist, and if they do, add them
+          echo "license:$plugin/$license readme:$plugin/$readme"
+          if [ ! -z "$license" ]; then
+            zip -r $zipname "$plugin/$license"
+          fi
+          if [ ! -z "$readme" ]; then
+            zip -r $zipname "$plugin/$readme"
+          fi
+        done
         popd
-
-    - name: Upload plugin artifact
-      uses: actions/upload-artifact@v3
+    - name: Upload Artifacts to Github
+      if: ${{ !env.ACT }}
+      uses: actions/upload-artifact@3cea5372237819ed00197afe530f5a7ea3e805c8
       with:
-        name: ${{ matrix.plugin }}
-        path: /tmp/${{ matrix.plugin }}.zip
+        name: plugins
+        path: /tmp/zips/*
+
+    - name: Upload plugins to store
+      if: ${{ !env.ACT }}
+      id: upload-plugins
+      run: |
+        shopt -s dotglob
+        for plugin in /tmp/output/*; do
+          zipname=/tmp/zips/$(basename ${plugin}).zip
+          pushd $plugin
+          donotupload=$(jq -r '.publish | any(.tags[] == "dnu"; .)' ./plugin.json)
+          if [[ "$donotupload" == "false" ]]; then
+            curl -X POST -H "Authorization: ${SUBMIT_AUTH_KEY}" -F "name=$(jq -r '.name' ./plugin.json)" -F "author=$(jq -r '.author' ./plugin.json)" -F "description=$(jq -r '.publish.description' ./plugin.json)" -F "tags=$(jq -r '.publish.tags|join(",")' ./plugin.json)" -F "version_name=$(jq -r '.version' ./package.json)" -F "image=$(jq -r '.publish.image' ./plugin.json)" -F "file=@${zipname}" ${STORE_URL}/__submit
+          else
+            echo "Plugin is designated as 'do not upload', likely a template or CI demonstration."
+          fi
+          popd
+        done
+      env:
+        SUBMIT_AUTH_KEY: ${{ secrets.SUBMIT_AUTH_KEY }}
+        STORE_URL: ${{ secrets.STORE_URL }}

--- a/.github/workflows/push-plugins-to-testing.yml
+++ b/.github/workflows/push-plugins-to-testing.yml
@@ -2,7 +2,7 @@ run-name : Deploy plugins from ${{ github.event.workflow_run.head_repository.nam
 
 on:
   workflow_run:
-    workflows: ["Build plugins"]
+    workflows: ["Build Plugins for testing"]
     types:
       - completed
 

--- a/.github/workflows/push-plugins-to-testing.yml
+++ b/.github/workflows/push-plugins-to-testing.yml
@@ -1,0 +1,98 @@
+run-name : Deploy plugins from ${{ github.event.workflow_run.head_repository.name }}/${{ github.event.workflow_run.head_branch }} (Workflow ID ${{ github.event.workflow_run.id }}) by @${{ github.event.workflow_run.actor.login }}
+
+on:
+  workflow_run:
+    workflows: ["Build plugins"]
+    types:
+      - completed
+
+jobs:
+  find_environment:
+    runs-on: ubuntu-latest
+    if: >
+      github.event.workflow_run.conclusion == 'success'
+    outputs:
+      environment: ${{ steps.find_environment.outputs.environment }}
+    steps:
+      - name: Find environment
+        id: find_environment
+        run: |
+          environment="testing_env"
+
+          if [[ "${{ github.event.workflow_run.event }}" == push && "${{ github.event.workflow_run.head_branch }}" == main ]]; then
+            environment="env"
+          fi
+
+          echo "environment=$environment" >> $GITHUB_OUTPUT
+
+  upload:
+    needs:
+      - find_environment
+    runs-on: ubuntu-latest
+    environment:
+      name: ${{ needs.find_environment.outputs.environment }}
+    steps:
+    - name: 'Download built plugins'
+      uses: actions/github-script@v6
+      with:
+        script: |
+          const fs = require('fs/promises');
+          const workspace = "${{ github.workspace }}";
+
+          const artifacts = await github.rest.actions.listWorkflowRunArtifacts({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              run_id: ${{ github.event.workflow_run.id }},
+          });
+
+          // Download all plugins
+          const promises = artifacts.data.artifacts.map(async (artifact) => {
+            const download = await github.rest.actions.downloadArtifact({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                artifact_id: artifact.id,
+                archive_format: 'zip',
+            });
+
+            await fs.writeFile(`${workspace}/${artifact.name}.zip`, Buffer.from(download.data));
+          });
+
+          await Promise.all(promises);
+
+    - name: Unzip plugins
+      run: |
+        mkdir -p ${{ github.workspace }}/plugins
+        cd ${{ github.workspace }}/plugins
+        unzip ${{ github.workspace }}/*.zip
+
+    - name: Upload plugin to store
+      if: ${{ !env.ACT }}
+      id: upload-plugins
+      run: |
+        echo "Uploading plugin to ${{ needs.find_environment.outputs.environment }}"
+        shopt -s dotglob
+        for plugin in ${{ github.workspace }}/plugins/*.zip; do
+          name=$(basename $plugin .zip)
+
+          metadata=$(unzip -p $plugin $name/plugin.json)
+          packagejson=$(unzip -p $plugin $name/package.json)
+
+          donotupload=$(jq -r '.publish | any(.tags[] == "dnu"; .)' <<< $metadata)
+          if [[ "$donotupload" == "false" ]]; then
+            curl -X POST \
+            -H "Authorization: ${SUBMIT_AUTH_KEY}" \
+            -F "name=$(jq -r '.name' <<< $metadata)" \
+            -F "author=$(jq -r '.author' <<< $metadata)" \
+            -F "description=$(jq -r '.publish.description' <<< $metadata)" \
+            -F "tags=$(jq -r '.publish.tags|join(",")' <<< $metadata)" \
+            -F "version_name=$(jq -r '.version' <<< $packagejson)" \
+            -F "image=$(jq -r '.publish.image' <<< $metadata)" \
+            -F "file=@${plugin}" ${STORE_URL}/__submit \
+            -v
+          else
+            echo "Plugin is designated as 'do not upload', likely a template or CI demonstration."
+          fi
+        done
+      env:
+        SUBMIT_AUTH_KEY: ${{ secrets.SUBMIT_AUTH_KEY }}
+        STORE_URL: ${{ secrets.STORE_URL }}

--- a/.gitmodules
+++ b/.gitmodules
@@ -101,3 +101,6 @@
 [submodule "plugins/sharedeck-y"]
 	path = plugins/sharedeck-y
 	url = https://github.com/davocarli/sharedeck-y
+[submodule "plugins/decky-wine-manager"]
+	path = plugins/decky-wine-manager
+	url = https://github.com/SkyLeite/decky-wine-manager.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -79,7 +79,7 @@
 	url = https://github.com/jurassicplayer/decky-autoflatpaks.git
 [submodule "plugins/SDH-KLang"]
 	path = plugins/SDH-KLang
-	url = https://github.com/Loidbae/SDH-KLang.git
+	url = git@github.com:Loidbae/SDH-KLang.git
 [submodule "plugins/moondeck"]
 	path = plugins/moondeck
 	url = https://github.com/FrogTheFrog/moondeck
@@ -101,6 +101,3 @@
 [submodule "plugins/sharedeck-y"]
 	path = plugins/sharedeck-y
 	url = https://github.com/davocarli/sharedeck-y
-[submodule "plugins/decky-wine-manager"]
-	path = plugins/decky-wine-manager
-	url = https://github.com/SkyLeite/decky-wine-manager.git


### PR DESCRIPTION
This PR makes it so CI builds and uploads plugins in parallel, as well as builds only the relevant plugins in a PR. The restriction of needing approval from a maintainer has also been moved specifically to the upload step, meaning plugins will be built when the PR is opened and kept on hold for upload until approved.