### PR TITLE
Add DeckMTP plugin

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -105,3 +105,6 @@
 [submodule "plugins/tailscale-control"]
 	path = plugins/tailscale-control
 	url = https://github.com/saumya-banthia/tailscale-control
+[submodule "plugins/DeckMTP"]
+	path = plugins/DeckMTP
+	url = https://github.com/dafta/DeckMTP


### PR DESCRIPTION
# DeckMTP

This plugin adds MTP functionality to the Deck, allowing file transfer to other PC's, phones, and Steam Decks via USB.
However, in order for the plugin to work, DRD needs to be enabled in BIOS to allow gadget mode.

## Checklist:

### Developer Checklist

- [x] I am the original author or an authorized maintainer of this plugin.
- [x] I have abided by the licenses of the libraries I am utilizing, including attaching license notices where appropriate.

### Plugin Checklist

- [x] I have verified that my plugin works properly on the Stable and Beta update channels of SteamOS.
- [x] I have verified my plugin is unique or alternatively provides more/alternative functionality to a similar plugin already on the store.

### Plugin Backend Checklist

- **Yes**: I am using a custom backend other than Python.
- **Yes**: I am using a tool or software from a 3rd party FOSS project that does not have it's dependencies [statically linked](https://en.wikipedia.org/wiki/Static_library).
- **No**: I am using a custom binary that has all of it's dependencies statically linked.

## Testing

- [x] Tested on SteamOS Stable Update Channel.
- [x] Tested on SteamOS Beta Update Channel.
<!-- If you answered "No" to all of the Plugin Backend Checklist then you may remove the below line for testing on preview channel. -->
- [x] Tested on SteamOS Preview Update Channel.
