### PR TITLE
Adding Deckshot

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -105,3 +105,6 @@
 [submodule "plugins/tailscale-control"]
 	path = plugins/tailscale-control
 	url = https://github.com/saumya-banthia/tailscale-control
+[submodule "plugins/deckshot"]
+	path = plugins/deckshot
+	url = https://github.com/apognu/deckshot


### PR DESCRIPTION
# Deckshot

Deckshot is an automatic screenshot uploader for the Steam Deck. It will automatically pick up screenshots as they are taken and upload them to the configured online storage or communication service (supporting S3, Google Drive, OneDrive, Dropbox, imgur and Discord, for now).

The configuration itself (mostly, selecting a storage service and authenticating to it) is to be performed outside of Decky UI, either through SSH or desktop mode. I don't know if it is an issue for publishing on Decky. Maybe it would at least be necessary to provide more information within the UI itself.

~**Note to reviewers:** is it probably not mergeable as is, I still need to check if it works properly on SteamOS Beta and Preview.~

## Checklist:

### Developer Checklist

- [x] I am the original author or an authorized maintainer of this plugin.
- [x] I have abided by the licenses of the libraries I am utilizing, including attaching license notices where appropriate.

### Plugin Checklist

- [x] I have verified that my plugin works properly on the Stable and Beta update channels of SteamOS.
- [x] I have verified my plugin is unique or alternatively provides more/alternative functionality to a similar plugin already on the store.

### Plugin Backend Checklist

- **Yes**: I am using a custom backend other than Python. The main functionnality is provided by a Rust program I created. I used to be standalone and now turned into a Decky plugin.
- **No**: I am using a tool or software from a 3rd party FOSS project that does not have it's dependencies [statically linked](https://en.wikipedia.org/wiki/Static_library).
- **No**: I am using a custom binary that has all of it's dependencies statically linked. The binary is dynamically linked, but reduced to the strict minimum (does not link to libssl, for example).

## Testing

- [ ] Tested on SteamOS Stable Update Channel.
- [ ] Tested on SteamOS Beta Update Channel.
- [ ] Tested on SteamOS Preview Update Channel.
