### PR TITLE
Parallelilze building and uploading of plugins

### DIFF
--- a/.github/workflows/build-plugins.yml
+++ b/.github/workflows/build-plugins.yml
@@ -5,7 +5,7 @@ on:
     branches:
       - main
       - backend-builder
-      - parallelize-ci
+      - concurrent-plugin-builds
     paths:
       - "plugins/**"
       - ".github/workflows/build-plugins.yml"
@@ -19,36 +19,58 @@ on:
 
 jobs:
   find_plugins:
+    environment:
+      name: ${{ (github.ref == 'refs/heads/main' && (github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && github.event.inputs.upload))) && 'env' || 'testing_env' }}
     outputs:
       plugins: ${{ steps.find_plugins.outputs.plugins }}
     runs-on: ubuntu-latest
     steps:
+      - name: Get Ref
+        id: get_ref
+        env:
+          isPr: ${{ github.event_name == 'pull_request_target' }}
+        run: |
+          if [[ $isPr == "true" ]]; then
+            REF=refs/pull/${{ github.event.number }}/merge
+          else
+            REF=${{ github.ref }}
+          fi
+
+          echo "ref=$REF" >> $GITHUB_OUTPUT
+
       - name: Checkout
         if: ${{ !env.ACT }}
         uses: actions/checkout@8230315d06ad95c617244d2f265d237a1682d445
         with:
+          ref: ${{ steps.get_ref.outputs.ref }}
           fetch-depth: 9
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Find plugins to be built
         id: find_plugins
         env:
-          isPr: ${{ github.event_name == 'pull_request' }}
+          isPr: ${{ github.event_name == 'pull_request_target' }}
         run: |
+          if [[ $isPr == "true" ]]; then
+            # Diff with the ref of the target branch
+            REF=(origin/${{ github.base_ref }})
+          else
+            # Diff with previous commit
+            REF=(${{ github.ref }} ${{ github.event.before }})
+          fi
+
+          git fetch --no-recurse-submodules --depth=3 --all
           workflow_changed=$(git diff --name-only --submodule=diff $REF -- .github/workflows/build-plugins.yml)
           if $workflow_changed; then
             # Workflow changed. Build everything to be safe
             PLUGINS=$(find ./plugins -mindepth 1 -maxdepth 1 -type d -print0 | xargs -0 -n1 -- basename | jq -Rsc 'split("\n")[:-1]')
           else
-            if [[ $isPr == "true" ]]; then
-              # Diff with the ref of the target branch
-              REF=${{ github.base_ref }}
-            else
-              # Diff with previous commit
-              REF=(${{ github.event.base_ref }} ${{ github.event.before }})
-            fi
 
-            PLUGINS=$(git diff --name-only --submodule=diff $REF -- plugins | xargs -0 -n1 -- basename | jq -Rsc 'split("\n")[:-2]')
+            git fetch --no-recurse-submodules --depth=3 --all
+            PLUGINS=$(git diff --name-only --submodule=diff ${REF[@]} -- plugins | xargs -0 -n1 -- basename | jq -Rsc 'split("\n")[:-2]')
+            echo ${REF[@]}
+            git diff --name-only --submodule=diff ${REF[@]} -- plugins
+            echo $PLUGINS
           fi
 
           echo "plugins=$PLUGINS" >> $GITHUB_OUTPUT
@@ -61,6 +83,7 @@ jobs:
     if: ${{ needs.find_plugins.outputs.plugins != '[]' }}
     continue-on-error: true
     strategy:
+      fail-fast: false
       matrix:
         plugin: ${{ fromJSON(needs.find_plugins.outputs.plugins) }}
     outputs:
@@ -233,17 +256,36 @@ jobs:
         name: ${{ matrix.plugin }}
         path: /tmp/${{ matrix.plugin }}.zip
 
+  find_successful_plugins:
+    runs-on: ubuntu-latest
+    outputs:
+      plugins: ${{ steps.find_plugins.outputs.plugins }}
+    needs:
+      - find_plugins
+      - build
+
+    steps:
+      - uses: actions/download-artifact@v3
+
+      - name: Find plugins that built successfully
+        id: find_plugins
+        run: |
+          PLUGINS=$(find . -mindepth 1 -maxdepth 1 -type d -print0 | xargs -0 -n1 -- basename | jq -Rsc 'split("\n")[:-1]')
+          echo "plugins=$PLUGINS" >> $GITHUB_OUTPUT
+
   upload:
     runs-on: ubuntu-latest
     needs:
       - find_plugins
       - build
-    if: ${{ needs.find_plugins.outputs.plugins != '[]' }}
+      - find_successful_plugins
+    if: ${{ needs.find_successful_plugins.outputs.plugins != '[]' }}
     environment:
       name: ${{ (github.ref == 'refs/heads/main' && (github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && github.event.inputs.upload))) && 'env' || 'testing_env' }}
     strategy:
+      fail-fast: false
       matrix:
-        plugin: ${{ fromJSON(needs.find_plugins.outputs.plugins) }}
+        plugin: ${{ fromJSON(needs.find_successful_plugins.outputs.plugins) }}
     steps:
     - uses: actions/download-artifact@v3
       with:

--- a/.github/workflows/build-plugins.yml
+++ b/.github/workflows/build-plugins.yml
@@ -1,10 +1,11 @@
-name: Build Plugins
+name: Build Plugins in Parallel
 
 on:
   push:
     branches:
       - main
       - backend-builder
+      - parallelize-ci
     paths:
       - "plugins/**"
       - ".github/workflows/build-plugins.yml"
@@ -17,11 +18,53 @@ on:
         description: Re-upload the plugins to the store
 
 jobs:
-  build:
-    name: Build updated plugins
+  find_plugins:
+    outputs:
+      plugins: ${{ steps.find_plugins.outputs.plugins }}
     runs-on: ubuntu-latest
-    environment:
-      name: ${{ (github.ref == 'refs/heads/main' && (github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && github.event.inputs.upload))) && 'env' || 'testing_env' }}    
+    steps:
+      - name: Checkout
+        if: ${{ !env.ACT }}
+        uses: actions/checkout@8230315d06ad95c617244d2f265d237a1682d445
+        with:
+          fetch-depth: 9
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Find plugins to be built
+        id: find_plugins
+        env:
+          isPr: ${{ github.event_name == 'pull_request' }}
+        run: |
+          workflow_changed=$(git diff --name-only --submodule=diff $REF -- .github/workflows/build-plugins.yml)
+          if $workflow_changed; then
+            # Workflow changed. Build everything to be safe
+            PLUGINS=$(find ./plugins -mindepth 1 -maxdepth 1 -type d -print0 | xargs -0 -n1 -- basename | jq -Rsc 'split("\n")[:-1]')
+          else
+            if [[ $isPr == "true" ]]; then
+              # Diff with the ref of the target branch
+              REF=${{ github.base_ref }}
+            else
+              # Diff with previous commit
+              REF=(${{ github.event.base_ref }} ${{ github.event.before }})
+            fi
+
+            PLUGINS=$(git diff --name-only --submodule=diff $REF -- plugins | xargs -0 -n1 -- basename | jq -Rsc 'split("\n")[:-2]')
+          fi
+
+          echo "plugins=$PLUGINS" >> $GITHUB_OUTPUT
+
+  build:
+    name: Build plugin
+    runs-on: ubuntu-latest
+    needs:
+      - find_plugins
+    if: ${{ needs.find_plugins.outputs.plugins != '[]' }}
+    continue-on-error: true
+    strategy:
+      matrix:
+        plugin: ${{ fromJSON(needs.find_plugins.outputs.plugins) }}
+    outputs:
+      name: ${{ steps.set_name.outputs.name }}
 
     steps:
     - name: Checkout
@@ -30,34 +73,11 @@ jobs:
       with:
         ref: ${{ github.event.pull_request.head.sha || github.sha }}
         fetch-depth: 0
-        submodules: "recursive"
         token: ${{ secrets.GITHUB_TOKEN }}
 
-    - name: Get changed files
-      id: changed-files
-      uses: tj-actions/changed-files@210f4edecfff9e901066850eb306b947d09092bc
-      with:
-        sha: ${{ github.event.pull_request.head.sha || github.sha }}
-        separator: ","
-        files: |
-          plugins/*
-          .github/workflows/build-plugins.yml
-
-    - name: Cache Docker images
-      if: ${{ !env.ACT }}
-      uses: satackey/action-docker-layer-caching@46d2c640b1d8ef50d185452ad6fb324e6bd1d052
-
-    - name: Login to GitHub Container Registry
+    - name: Checkout plugin submodule
       run: |
-        echo $GITHUB_TOKEN | docker login ghcr.io -u SteamDeckHomebrew --password-stdin
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-    - name: Wait for other runs to complete
-      if: ${{ !env.ACT }}
-      uses: pau1ocampos/turnstyle@17e7c2e349edeb2fc92d15e99f389c6011e02956
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        git submodule update --init --depth 1 plugins/${{ matrix.plugin }}
 
     - name: Pull frontend builder image
       run: docker pull ghcr.io/steamdeckhomebrew/builder:latest
@@ -65,97 +85,65 @@ jobs:
     - name: Pull backend builder image
       run: docker pull ghcr.io/steamdeckhomebrew/holo-base:latest
 
-    - name: Log out of GitHub Container Registry
+    - name: Build plugin backend
       run: |
-        docker logout ghcr.io
-
-    - name: Detect edited files/plugins
-      id: list-files
-      run: |
+        plugin=${{ matrix.plugin }}
         pushd plugins
-        files=()
-        if [[ "${{ steps.changed-files.outputs.all_changed_files }}" == *".github/workflows/build-plugins.yml"* || "${{ (github.event_name == 'workflow_dispatch' && github.event.inputs.upload) && 'true' }}" == "true" ]]; 
-        then
-          echo "Rebuilding all plugins due to workflow edit"
-          for file in ./plugins/*; do
-            files+=($(cut -d/ -f3 <<< $file))
-          done
-        else
-          rest="${{ steps.changed-files.outputs.all_changed_files }}"
-          while [ -n "$rest" ] ; do
-            str=${rest%%,*}
-            [ "$rest" = "${rest/,/}" ] && rest= || rest=${rest#*,}
-            files+=($(cut -d/ -f2 <<< $str))
-          done <<< "$files"
-          printf "%s\n" "${files[@]}" | sort -u
-        fi
-        popd
-        IFS=$'\n' sorted=($(sort -u <<<"${files[@]}"))
-        unset $IFS
-        echo "${sorted[@]}"
-        echo edited_files=${sorted[@]} >> $GITHUB_OUTPUT
-    
-    - name: Build plugin backends
-      run: |
-        IFS=' ' read -ra files <<< "${{ steps.list-files.outputs.edited_files }}"
-        pushd plugins
-        for plugin in $(printf "%s\n" "${files[@]}" | sort -u); do
-          pushd $plugin
-          echo "Detecting backend for plugin $plugin"
-          dockerfile_exists="false"
-          entrypoint_exists="false"
-          docker_name="backend-${plugin,,}"
-          # [ -d $PWD/backend ] && echo "$(ls -lla $PWD/backend | grep Dockerfile)"
-          [ -f $PWD/backend/Dockerfile ] && dockerfile_exists=true
-          [ -f $PWD/backend/entrypoint.sh ] && entrypoint_exists=true
-          # check for Dockerfile
-          if [[ "$dockerfile_exists" == "true" ]]; then
-            echo "Grabbing provided dockerfile."
-            echo "Building provided Dockerfile."
-            docker build -f $PWD/backend/Dockerfile -t "$docker_name" .
-            mkdir -p /tmp/output/$plugin/backend/out
-            # check entrypoint script exists
-            if [[ "$entrypoint_exists" == "true" ]]; then
-              echo "Running docker image "$docker_name" with provided entrypoint script."
-              docker run --rm -i -v $PWD/backend:/backend -v /tmp/output/$plugin/backend/out:/backend/out --entrypoint /backend/entrypoint.sh "$docker_name"
-              mkdir -p /tmp/output/$plugin/bin
-              cp -r /tmp/output/$plugin/backend/out/. /tmp/output/$plugin/bin
-            else
-              echo "Running docker image "$docker_name" with entrypoint script specified in Dockerfile."
-              docker run --rm -i -v $PWD/backend:/backend -v /tmp/output/$plugin/backend/out:/backend/out "$docker_name"
-              mkdir -p /tmp/output/$plugin/bin
-              cp -r /tmp/output/$plugin/backend/out/. /tmp/output/$plugin/bin
-            fi
-            docker image rm "$docker_name"
-            echo "Built $plugin backend"
-          # Dockerfile doesn't exist but entrypoint script does, run w/ default image
-          elif [[ "$dockerfile_exists" == "false" && "$entrypoint_exists" == "true" ]]; then
-            echo "Grabbing default docker image and using provided entrypoint script."
-            docker run --rm -i -v $PWD/backend:/backend -v /tmp/output/$plugin/backend/out:/backend/out ghcr.io/steamdeckhomebrew/holo-base:latest
+        pushd $plugin
+        echo "Detecting backend for plugin $plugin"
+        dockerfile_exists="false"
+        entrypoint_exists="false"
+        docker_name="backend-${plugin,,}"
+        # [ -d $PWD/backend ] && echo "$(ls -lla $PWD/backend | grep Dockerfile)"
+        [ -f $PWD/backend/Dockerfile ] && dockerfile_exists=true
+        [ -f $PWD/backend/entrypoint.sh ] && entrypoint_exists=true
+        # check for Dockerfile
+        if [[ "$dockerfile_exists" == "true" ]]; then
+          echo "Grabbing provided dockerfile."
+          echo "Building provided Dockerfile."
+          docker build -f $PWD/backend/Dockerfile -t "$docker_name" .
+          mkdir -p /tmp/output/$plugin/backend/out
+          # check entrypoint script exists
+          if [[ "$entrypoint_exists" == "true" ]]; then
+            echo "Running docker image "$docker_name" with provided entrypoint script."
+            docker run --rm -i -v $PWD/backend:/backend -v /tmp/output/$plugin/backend/out:/backend/out --entrypoint /backend/entrypoint.sh "$docker_name"
             mkdir -p /tmp/output/$plugin/bin
-            cp /tmp/output/$plugin/backend/out/. /tmp/output/$plugin/bin
-            echo "Built $plugin backend"
+            cp -r /tmp/output/$plugin/backend/out/. /tmp/output/$plugin/bin
           else
-            echo "Plugin $plugin does not have a backend"
+            echo "Running docker image "$docker_name" with entrypoint script specified in Dockerfile."
+            docker run --rm -i -v $PWD/backend:/backend -v /tmp/output/$plugin/backend/out:/backend/out "$docker_name"
+            mkdir -p /tmp/output/$plugin/bin
+            cp -r /tmp/output/$plugin/backend/out/. /tmp/output/$plugin/bin
           fi
-          # ls -lla /tmp/output/$plugin
-          popd
-        done
+          docker image rm "$docker_name"
+          echo "Built $plugin backend"
+        # Dockerfile doesn't exist but entrypoint script does, run w/ default image
+        elif [[ "$dockerfile_exists" == "false" && "$entrypoint_exists" == "true" ]]; then
+          echo "Grabbing default docker image and using provided entrypoint script."
+          docker run --rm -i -v $PWD/backend:/backend -v /tmp/output/$plugin/backend/out:/backend/out ghcr.io/steamdeckhomebrew/holo-base:latest
+          mkdir -p /tmp/output/$plugin/bin
+          cp /tmp/output/$plugin/backend/out/. /tmp/output/$plugin/bin
+          echo "Built $plugin backend"
+        else
+          echo "Plugin $plugin does not have a backend"
+        fi
+        # ls -lla /tmp/output/$plugin
+        popd
         popd
 
-    - name: Build plugin frontends
+    - name: Build plugin frontend
       run: |
-        IFS=' ' read -ra files <<< "${{ steps.list-files.outputs.edited_files }}"
+        shopt -s extglob
         pushd plugins
-        for plugin in $(printf "%s\n" "${files[@]}" | sort -u); do
-          pushd $plugin
-          docker run --rm -i -v $PWD:/plugin -v /tmp/output/$plugin:/out ghcr.io/steamdeckhomebrew/builder:latest
-          echo Built $plugin frontend
-          ls -lla /tmp/output/$plugin
-          popd
-        done
+        plugin=${{ matrix.plugin }}
+        pushd $plugin
+        docker run --rm -i -v $PWD:/plugin -v /tmp/output/$plugin:/out ghcr.io/steamdeckhomebrew/builder:latest
+        echo Built $plugin frontend
+        ls -lla /tmp/output/$plugin
+        cd /tmp/output/$plugin
         popd
-        
+        popd
+
     - name: Zip Plugins
       run: |
         shopt -s dotglob
@@ -164,105 +152,128 @@ jobs:
         redtext=$'\e[1;31m'
         end=$'\e[0m'
         pushd /tmp/output
-        for abs_plugin in /tmp/output/*; do
-          plugin=$(basename $abs_plugin)
-          zipname=/tmp/zips/$(basename ${plugin}).zip
-          echo $plugin
+        plugin=$(basename ${{ matrix.plugin }})
+        zipname=/tmp/$plugin.zip
+        echo $plugin
 
-          # Names of the optional files (the license can either be called license or license.md, not both)
-          # (head is there to take the first file, because we're assuming there's only a single license file)
-          license="$(find $plugin -maxdepth 1 -type f \( -iname "license" -o -iname "license.md" \) -printf '%P\n' | head -n 1)"
-          readme="$(find $plugin -maxdepth 1 -type f -iname 'readme.md' -printf '%P\n')"
-          haspython="$(find $plugin -maxdepth 1 -type f -name '*.py' -printf '%P\n')"
-          # Check if plugin has a bin folder, if so, add "bin" and it's contents to root dir
-          hasbin="$(find $plugin -maxdepth 1 -type d -name 'bin' -printf '%P\n')"
-          # Check if plugin has a defaults folder, if so, add "default" contents to root dir
-          hasdefaults="$(find $plugin -maxdepth 1 -type d -name 'defaults' -printf '%P\n')"
-          if [[ "${{ secrets.STORE_ENV }}" == "testing" ]]; then
-            long_sha="${{ github.event.pull_request.head.sha || github.sha }}"
-            sha=$(echo $long_sha | cut -c1-7)
-            cat $plugin/package.json | jq --arg jqsha "$sha" '.version |= . + "-" + $jqsha' | sudo tee $plugin/$sha-package.json
-            sudo mv $plugin/$sha-package.json $plugin/package.json
-          fi
-          # Add required plugin files (and directory) to zip file
-          echo "$plugin/dist $plugin/plugin.json $plugin/package.json"
-          zip -r $zipname "$plugin/dist" "$plugin/plugin.json" "$plugin/package.json"
-          if [ ! -z "$hasbin" ]; then
-            echo "$plugin/bin"
-            zip -r $zipname "$plugin/bin"
-          fi
+        # Names of the optional files (the license can either be called license or license.md, not both)
+        # (head is there to take the first file, because we're assuming there's only a single license file)
+        license="$(find $plugin -maxdepth 1 -type f \( -iname "license" -o -iname "license.md" \) -printf '%P\n' | head -n 1)"
+        readme="$(find $plugin -maxdepth 1 -type f -iname 'readme.md' -printf '%P\n')"
+        haspython="$(find $plugin -maxdepth 1 -type f -name '*.py' -printf '%P\n')"
+        # Check if plugin has a bin folder, if so, add "bin" and it's contents to root dir
+        hasbin="$(find $plugin -maxdepth 1 -type d -name 'bin' -printf '%P\n')"
+        # Check if plugin has a defaults folder, if so, add "default" contents to root dir
+        hasdefaults="$(find $plugin -maxdepth 1 -type d -name 'defaults' -printf '%P\n')"
+        if [[ "${{ secrets.STORE_ENV }}" == "testing" ]]; then
+          long_sha="${{ github.event.pull_request.head.sha || github.sha }}"
+          sha=$(echo $long_sha | cut -c1-7)
+          cat $plugin/package.json | jq --arg jqsha "$sha" '.version |= . + "-" + $jqsha' | sudo tee $plugin/$sha-package.json
+          sudo mv $plugin/$sha-package.json $plugin/package.json
+        fi
+        # Add required plugin files (and directory) to zip file
+        echo "$plugin/dist $plugin/plugin.json $plugin/package.json"
+        zip -r $zipname "$plugin/dist" "$plugin/plugin.json" "$plugin/package.json"
+        if [ ! -z "$hasbin" ]; then
+          echo "$plugin/bin"
+          zip -r $zipname "$plugin/bin"
+        fi
 
-          if [ ! -z "$haspython" ]; then
-            echo "$plugin/*.py"
-            find $plugin -maxdepth 1 -type f -name '*.py' -exec zip -r $zipname {} \;
-          fi
+        if [ ! -z "$haspython" ]; then
+          echo "$plugin/*.py"
+          find $plugin -maxdepth 1 -type f -name '*.py' -exec zip -r $zipname {} \;
+        fi
 
-          if [ ! -z "$hasdefaults" ]; then
-            export workingdir=$PWD
-            cd $plugin/defaults
-            export plugin="$plugin"
-            export zipname="$zipname"
-            if [ ! -f "defaults.txt" ]; then
-              find . -mindepth 1 -type d,f -name '*' -exec bash -c '
-                for object do
-                  outdir="/tmp/output"
-                  name="$(basename $object)"
-                  # echo "object = $object, name = $name"
-                  if [ -e "$object" ]; then
-                    sudo mv "$object" $outdir/$plugin/$name
-                    moved="$?"
-                    # echo "moved = $moved"
-                    cd $workingdir
-                    if [ "$moved" = "0" ]; then
-                      zip -r $zipname $plugin/$name
-                    fi
+        if [ ! -z "$hasdefaults" ]; then
+          export workingdir=$PWD
+          cd $plugin/defaults
+          export plugin="$plugin"
+          export zipname="$zipname"
+          if [ ! -f "defaults.txt" ]; then
+            find . -mindepth 1 -type d,f -name '*' -exec bash -c '
+              for object do
+                outdir="/tmp/output"
+                name="$(basename $object)"
+                # echo "object = $object, name = $name"
+                if [ -e "$object" ]; then
+                  sudo mv "$object" $outdir/$plugin/$name
+                  moved="$?"
+                  # echo "moved = $moved"
+                  pushd $workingdir
+                  if [ "$moved" = "0" ]; then
+                    zip -r $zipname $plugin/$name
                   fi
-                done
-              ' find-sh {} + ;
+                  popd
+                fi
+              done
+            ' find-sh {} + ;
+          else
+            if [[ ! "$plugin" =~ "plugin-template" ]]; then
+              printf "${red}defaults.txt found in defaults folder, please remove either defaults.txt or the defaults folder.${end}\n"
             else
-              if [[ ! "$plugin" =~ "plugin-template" ]]; then
-                printf "${red}defaults.txt found in defaults folder, please remove either defaults.txt or the defaults folder.${end}\n"
-              else
-                printf "plugin template, allowing defaults.txt\n"
-              fi
+              printf "plugin template, allowing defaults.txt\n"
             fi
-            cd "$workingdir"
           fi
+          cd "$workingdir"
+        fi
 
-          # Check if other files exist, and if they do, add them
-          echo "license:$plugin/$license readme:$plugin/$readme"
-          if [ ! -z "$license" ]; then
-            zip -r $zipname "$plugin/$license"
-          fi
-          if [ ! -z "$readme" ]; then
-            zip -r $zipname "$plugin/$readme"
-          fi
-        done
+        # Check if other files exist, and if they do, add them
+        echo "license:$plugin/$license readme:$plugin/$readme"
+        if [ ! -z "$license" ]; then
+          zip -r $zipname "$plugin/$license"
+        fi
+        if [ ! -z "$readme" ]; then
+          zip -r $zipname "$plugin/$readme"
+        fi
         popd
 
-    - name: Upload Artifacts to Github
-      if: ${{ !env.ACT }}
-      uses: actions/upload-artifact@3cea5372237819ed00197afe530f5a7ea3e805c8
+    - name: Upload plugin artifact
+      uses: actions/upload-artifact@v3
       with:
-        name: plugins
-        path: /tmp/zips/*
+        name: ${{ matrix.plugin }}
+        path: /tmp/${{ matrix.plugin }}.zip
 
-    - name: Upload plugins to store
+  upload:
+    runs-on: ubuntu-latest
+    needs:
+      - find_plugins
+      - build
+    if: ${{ needs.find_plugins.outputs.plugins != '[]' }}
+    environment:
+      name: ${{ (github.ref == 'refs/heads/main' && (github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && github.event.inputs.upload))) && 'env' || 'testing_env' }}
+    strategy:
+      matrix:
+        plugin: ${{ fromJSON(needs.find_plugins.outputs.plugins) }}
+    steps:
+    - uses: actions/download-artifact@v3
+      with:
+        name: ${{ matrix.plugin }}
+
+    - name: Upload plugin to store
       if: ${{ !env.ACT }}
       id: upload-plugins
       run: |
         shopt -s dotglob
-        for plugin in /tmp/output/*; do
-          zipname=/tmp/zips/$(basename ${plugin}).zip
-          pushd $plugin
-          donotupload=$(jq -r '.publish | any(.tags[] == "dnu"; .)' ./plugin.json)
-          if [[ "$donotupload" == "false" ]]; then
-            curl -X POST -H "Authorization: ${SUBMIT_AUTH_KEY}" -F "name=$(jq -r '.name' ./plugin.json)" -F "author=$(jq -r '.author' ./plugin.json)" -F "description=$(jq -r '.publish.description' ./plugin.json)" -F "tags=$(jq -r '.publish.tags|join(",")' ./plugin.json)" -F "version_name=$(jq -r '.version' ./package.json)" -F "image=$(jq -r '.publish.image' ./plugin.json)" -F "file=@${zipname}" ${STORE_URL}/__submit
-          else
-            echo "Plugin is designated as 'do not upload', likely a template or CI demonstration."
-          fi
-          popd
-        done
+        plugin=${{ matrix.plugin }}
+        zipname=$(basename ${plugin}).zip
+
+        metadata=$(unzip -p $zipname $plugin/plugin.json)
+        packagejson=$(unzip -p $zipname $plugin/package.json)
+
+        donotupload=$(jq -r '.publish | any(.tags[] == "dnu"; .)' <<< $metadata)
+        if [[ "$donotupload" == "false" ]]; then
+          curl -X POST \
+          -H "Authorization: ${SUBMIT_AUTH_KEY}" \
+          -F "name=$(jq -r '.name' <<< $metadata)" \
+          -F "author=$(jq -r '.author' <<< $metadata)" \
+          -F "description=$(jq -r '.publish.description' <<< $metadata)" \
+          -F "tags=$(jq -r '.publish.tags|join(",")' <<< $metadata)" \
+          -F "version_name=$(jq -r '.version' <<< $packagejson)" \
+          -F "image=$(jq -r '.publish.image' <<< $metadata)" \
+          -F "file=@${zipname}" ${STORE_URL}/__submit
+        else
+          echo "Plugin is designated as 'do not upload', likely a template or CI demonstration."
+        fi
       env:
         SUBMIT_AUTH_KEY: ${{ secrets.SUBMIT_AUTH_KEY }}
         STORE_URL: ${{ secrets.STORE_URL }}

--- a/.gitmodules
+++ b/.gitmodules
@@ -79,7 +79,7 @@
 	url = https://github.com/jurassicplayer/decky-autoflatpaks.git
 [submodule "plugins/SDH-KLang"]
 	path = plugins/SDH-KLang
-	url = git@github.com:Loidbae/SDH-KLang.git
+	url = https://github.com/Loidbae/SDH-KLang.git
 [submodule "plugins/moondeck"]
 	path = plugins/moondeck
 	url = https://github.com/FrogTheFrog/moondeck
@@ -101,3 +101,6 @@
 [submodule "plugins/sharedeck-y"]
 	path = plugins/sharedeck-y
 	url = https://github.com/davocarli/sharedeck-y
+[submodule "plugins/decky-wine-manager"]
+	path = plugins/decky-wine-manager
+	url = https://github.com/SkyLeite/decky-wine-manager.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -104,3 +104,6 @@
 [submodule "plugins/decky-wine-manager"]
 	path = plugins/decky-wine-manager
 	url = https://github.com/SkyLeite/decky-wine-manager.git
+[submodule "plugins/decky-proton-manager"]
+	path = plugins/decky-proton-manager
+	url = https://github.com/SkyLeite/decky-wine-manager.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -104,6 +104,3 @@
 [submodule "plugins/decky-wine-manager"]
 	path = plugins/decky-wine-manager
 	url = https://github.com/SkyLeite/decky-wine-manager.git
-[submodule "plugins/decky-proton-manager"]
-	path = plugins/decky-proton-manager
-	url = https://github.com/SkyLeite/decky-wine-manager.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -79,7 +79,7 @@
 	url = https://github.com/jurassicplayer/decky-autoflatpaks.git
 [submodule "plugins/SDH-KLang"]
 	path = plugins/SDH-KLang
-	url = https://github.com/Loidbae/SDH-KLang.git
+	url = git@github.com:Loidbae/SDH-KLang.git
 [submodule "plugins/moondeck"]
 	path = plugins/moondeck
 	url = https://github.com/FrogTheFrog/moondeck
@@ -101,6 +101,3 @@
 [submodule "plugins/sharedeck-y"]
 	path = plugins/sharedeck-y
 	url = https://github.com/davocarli/sharedeck-y
-[submodule "plugins/decky-wine-manager"]
-	path = plugins/decky-wine-manager
-	url = https://github.com/SkyLeite/decky-wine-manager.git


### PR DESCRIPTION
This PR makes it so plugins are built and uploaded in parallel, regardless if it's a PR or a push to main.

One drawback is that due to `pull_request_target` still being used, this workflow needs 2 approvals: one before anything is done at all (to give maintainers a chance to audit the code before it's built), and one right before uploading the artifacts to the store (to actually access the secrets).

Once we move on to using the `pull_request` in the future, this limitation will be eliminated.