### PR TITLE
Added tailscale control plugin as submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -102,3 +102,6 @@
 [submodule "plugins/sharedeck-y"]
 	path = plugins/sharedeck-y
 	url = https://github.com/davocarli/sharedeck-y
+[submodule "plugins/tailscale-control"]
+	path = plugins/tailscale-control
+	url = https://github.com/saumya-banthia/tailscale-control


### PR DESCRIPTION
# Tailscale Control

A Decky plugin to activate and deactivate Tailscale, while staying in Gaming mode.

[Note: Tailscale needs to be installed, this works only like a switch for the same.]

Since Tailscale is a pre-requisite, the README.md for Tailscale Control provides instructions on how it can be installed:

https://github.com/saumya-banthia/tailscale-control#pre-requisites

## Checklist:

### Developer Checklist

- [x] I am the original author or an authorized maintainer of this plugin.
- [x] I have abided by the licenses of the libraries I am utilizing, including attaching license notices where appropriate.

### Plugin Checklist

- [x] I have verified that my plugin works properly on the Stable and Beta update channels of SteamOS.
- [x] I have verified my plugin is unique or alternatively provides more/alternative functionality to a similar plugin already on the store.

<!-- The following section needs to be modified as yes/no answers by the plugin developer. -->

<!-- Ex: "**Yes/No**: ..." becomes "**Yes**: ..." -->

### Plugin Backend Checklist

- **No**: I am using a custom backend other than Python.
- **No**: I am using a tool or software from a 3rd party FOSS project that does not have it's dependencies [statically linked](https://en.wikipedia.org/wiki/Static_library).
- **No**: I am using a custom binary that has all of it's dependencies statically linked.

<!-- The following section is for testers and maintainers, please do not modify it unless you don't meet the criteria for testing on the preview channel. -->

## Testing

- [x] Tested on SteamOS Stable Update Channel.
<!-- Leave me be unless you don't need preview testing, I just make the buttons look nice -->
- [x] Tested on SteamOS Beta Update Channel.
