### PR TITLE
Add Decky-WOL plugin

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -108,6 +108,3 @@
 [submodule "plugins/DeckMTP"]
 	path = plugins/DeckMTP
 	url = https://github.com/dafta/DeckMTP
-[submodule "plugins/decky-wol"]
-	path = plugins/decky-wol
-	url = https://github.com/scramble45/decky-wol

--- a/.gitmodules
+++ b/.gitmodules
@@ -108,6 +108,4 @@
 [submodule "plugins/DeckMTP"]
 	path = plugins/DeckMTP
 	url = https://github.com/dafta/DeckMTP
-[submodule "plugins/decky-wol"]
-	path = plugins/decky-wol
-	url = https://github.com/scramble45/decky-wol
+

--- a/.gitmodules
+++ b/.gitmodules
@@ -108,3 +108,6 @@
 [submodule "plugins/DeckMTP"]
 	path = plugins/DeckMTP
 	url = https://github.com/dafta/DeckMTP
+[submodule "plugins/decky-wol"]
+	path = plugins/decky-wol
+	url = https://github.com/scramble45/decky-wol

--- a/.gitmodules
+++ b/.gitmodules
@@ -108,4 +108,6 @@
 [submodule "plugins/DeckMTP"]
 	path = plugins/DeckMTP
 	url = https://github.com/dafta/DeckMTP
-
+[submodule "plugins/decky-wol"]
+	path = plugins/decky-wol
+	url = https://github.com/scramble45/decky-wol


### PR DESCRIPTION
# DeckyWOL

This is a semi-simple Bash wrapper for toggling the following and monitoring its state:
`sudo iw phy0 wowlan enable magic-packet disconnect`
`sudo iw phy0 wowlan disable`

It also has two systemd services that go along with this:
- One to ensure that we interrupt the hibernation with a call to S3 suspend instead, as WoWLAN wont work in hibernation.
- The other makes sure the hardware is unblocked (could be removed in another update or two).


> TLDR: You can put your SteamDeck to sleep, if DeckyWOL is enabled you can turn back on via WoWLAN magic packet - only Wi-Fi... wired soon.

**How to test:**
- Click on magic toggle
- Press your SteamDeck top power button once to put it to sleep
- Use a tool such as: `wakeonlan` to wake up your deck: `ie: $ wakeonlan 0a:de:ea:db:ee:fe`, our be fancy and setup homebridge to toggle it from your phone.
- You can also verify via systemctl that the enable / disable states change appropriately when the toggle is used
- Can also check that the hibernation redirect is working by using: `sudo journalctl -kf` when the deck starts to hibernate its told to just use S3 state instead.

## Shower Thoughts:
- No idea how this effects the battery.
- Not sure there is any impact if you disable wifi power management option in steam developer menu.
- Why didn't valve give us an official option?

## To Do Items (future release):
- Add support for wired device

---

## Checklist:

### Developer Checklist

- [x] I am the original author or an authorized maintainer of this plugin.
- [x] I have abided by the licenses of the libraries I am utilizing, including attaching license notices where appropriate.

### Plugin Checklist

- [x] I have verified that my plugin works properly on the Stable and Beta update channels of SteamOS.
- [x] I have verified my plugin is unique or alternatively provides more/alternative functionality to a similar plugin already on the store.

### Plugin Backend Checklist

- **Yes**: I am using a custom backend other than Python.
- **Yes**: I am using a tool or software from a 3rd party FOSS project that does not have it's dependencies [statically linked](https://en.wikipedia.org/wiki/Static_library).
- **No**: I am using a custom binary that has all of it's dependencies statically linked.

<!-- The following section is for testers and maintainers, please do not modify it unless you don't meet the criteria for testing on the preview channel. -->

## Testing

- [ ] Tested on SteamOS Stable Update Channel.
- [ ] Tested on SteamOS Beta Update Channel.
- [ ] Tested on SteamOS Preview Update Channel.
