### PR TITLE
Update Decky-Recorder 0.0.4

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -108,3 +108,6 @@
 [submodule "plugins/DeckMTP"]
 	path = plugins/DeckMTP
 	url = https://github.com/dafta/DeckMTP
+[submodule "plugins/decky-recorder"]
+	path = plugins/decky-recorder
+	url = git@github.com:marissa999/decky-recorder.git


### PR DESCRIPTION
# Decky Recorder

Version 0.0.4
- Changed the picture in the plugin.json
- Added the option to output .mp4, .mkv and mov
- Added a lot of useless methods that currently do not do anything

This plugin allows the user to start and stop a recording of the screen + audio of the Steam Deck. This plugin is heavily based on the recapture-plugin for Crankshaft.

## Checklist:

### Developer Checklist

- [X] I am the original author or an authorized maintainer of this plugin.
- [X] I have abided by the licenses of the libraries I am utilizing, including attaching license notices where appropriate.

### Plugin Checklist

- [X] I have verified that my plugin works properly on the Stable and Beta update channels of SteamOS.
- [X] I have verified my plugin is unique or alternatively provides more/alternative functionality to a similar plugin already on the store.

<!-- The following section needs to be modified as yes/no answers by the plugin developer. -->

<!-- Ex: "**Yes/No**: ..." becomes "**Yes**: ..." -->

### Plugin Backend Checklist

- **No**: I am using a custom backend other than Python.
Note: I do use the original gst-launcher-1.0 from SteamOS (which I call through Python), but I am downloading extra dependencies in a Holo-Base--Docker-Container and use those additional libraries as part of the gst-launcher-1.0-command
- **No**: I am using a tool or software from a 3rd party FOSS project that does not have it's dependencies [statically linked](https://en.wikipedia.org/wiki/Static_library).
- **No**: I am using a custom binary that has all of it's dependencies statically linked.

<!-- The following section is for testers and maintainers, please do not modify it unless you don't meet the criteria for testing on the preview channel. -->

## Testing

- [x] Tested on SteamOS Stable Update Channel.
<!-- Leave me be unless you don't need preview testing, I just make the buttons look nice -->
- [x] Tested on SteamOS Beta Update Channel.