### PR TITLE
Add QuickLaunch plugin

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -105,3 +105,6 @@
 [submodule "plugins/deck-roulette"]
 	path = plugins/deck-roulette
 	url = git@github.com:davocarli/deck-roulette.git
+[submodule "plugins/SDH-QuickLaunch"]
+	path = plugins/SDH-QuickLaunch
+	url = https://github.com/Fisch03/SDH-QuickLaunch


### PR DESCRIPTION
# QuickLaunch
Plugin to quickly Launch Apps from the QAM without adding them as shortcuts, or add new Shortcuts entirely

## Checklist:

### Developer Checklist

- [x] I am the original author or an authorized maintainer of this plugin.
- [x] I have abided by the licenses of the libraries I am utilizing, including attaching license notices where appropriate.

### Plugin Checklist

- [x] I have verified that my plugin works properly on the Stable and Beta update channels of SteamOS.
- [x] I have verified my plugin is unique or alternatively provides more/alternative functionality to a similar plugin already on the store.

<!-- The following section needs to be modified as yes/no answers by the plugin developer. -->

<!-- Ex: "**Yes/No**: ..." becomes "**Yes**: ..." -->

### Plugin Backend Checklist

- **No**: I am using a custom backend other than Python.
- **No**: I am using a tool or software from a 3rd party FOSS project that does not have it's dependencies [statically linked](https://en.wikipedia.org/wiki/Static_library).
- **No**: I am using a custom binary that has all of it's dependencies statically linked.

<!-- The following section is for testers and maintainers, please do not modify it unless you don't meet the criteria for testing on the preview channel. -->

## Testing

- [x] Tested on SteamOS Stable Update Channel.
<!-- Leave me be unless you don't need preview testing, I just make the buttons look nice -->
- [x] Tested on SteamOS Beta Update Channel.
<!-- If you answered "No" to all of the Plugin Backend Checklist then you may remove the below line for testing on preview channel. -->
- [x] Tested on SteamOS Preview Update Channel.
