### PR TITLE
add decky-dictation plugin

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -117,3 +117,6 @@
 [submodule "plugins/decky-networkinfo"]
 	path = plugins/decky-networkinfo
 	url = https://github.com/kimar/decky-networkinfo
+[submodule "plugins/decky-dictation"]
+	path = plugins/decky-dictation
+	url = git@github.com:cboiangiu/decky-dictation.git


### PR DESCRIPTION
# Decky Dictation

Allows speech to text input using [Vosk](https://github.com/alphacep/vosk-api) and [Nerd Dictation](https://github.com/ideasman42/nerd-dictation)

## Checklist:

### Developer Checklist

- [x] I am the original author or an authorized maintainer of this plugin.
- [x] I have abided by the licenses of the libraries I am utilizing, including attaching license notices where appropriate.

### Plugin Checklist

- [x] I have verified that my plugin works properly on the Stable and Beta update channels of SteamOS.
- [x] I have verified my plugin is unique or alternatively provides more/alternative functionality to a similar plugin already on the store.

<!-- The following section needs to be modified as yes/no answers by the plugin developer. -->

<!-- Ex: "**Yes/No**: ..." becomes "**Yes**: ..." -->

### Plugin Backend Checklist

- **No**: I am using a custom backend other than Python.
- **No**: I am using a tool or software from a 3rd party FOSS project that does not have it's dependencies [statically linked](https://en.wikipedia.org/wiki/Static_library).
- **No**: I am using a custom binary that has all of it's dependencies statically linked.

<!-- The following section is for testers and maintainers, please do not modify it unless you don't meet the criteria for testing on the preview channel. -->

## Testing

- [x] Tested on SteamOS Stable Update Channel.
- [x] Tested on SteamOS Beta Update Channel.