### PR TITLE
Update Decky Recorder to v0.2.1

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -99,6 +99,7 @@
 [submodule "plugins/decky-recorder"]
 	path = plugins/decky-recorder
 	url = https://github.com/marissa999/decky-recorder.git
+	branch = main-0.2.1
 [submodule "plugins/Steamback"]
 	path = plugins/Steamback
 	url = https://github.com/geeksville/steamback.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -98,7 +98,7 @@
 	url = https://github.com/dafta/DeckMTP
 [submodule "plugins/decky-recorder"]
 	path = plugins/decky-recorder
-	url = git@github.com:marissa999/decky-recorder.git
+	url = https://github.com/marissa999/decky-recorder.git
 [submodule "plugins/Steamback"]
 	path = plugins/Steamback
 	url = https://github.com/geeksville/steamback.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -108,3 +108,6 @@
 [submodule "plugins/DeckMTP"]
 	path = plugins/DeckMTP
 	url = https://github.com/dafta/DeckMTP
+[submodule "plugins/decky-recorder"]
+	path = plugins/decky-recorder
+	url = git@github.com:marissa999/decky-recorder.git


### PR DESCRIPTION
# Decky Recorder 0.2.1

(see https://github.com/SteamDeckHomebrew/decky-plugin-database/pull/296 only modifications are changing submodule to https and updating lockfile)

Changes:
- Changed shortcut for replays to STEAM + Start (was originally STEAM + Y but apparently that conflicts with a few things, see https://github.com/marissa999/decky-recorder/issues/14) (https://github.com/marissa999/decky-recorder/commit/6f78b558287c44807536d6d1578d3f70609a0b25)
- Changed image to png (https://github.com/marissa999/decky-recorder/commit/47fe1b683cffabf0af9be3dbda13e654344d22c8)

This plugin allows the user to start and stop a recording of the screen + audio of the Steam Deck. This plugin is heavily based on the recapture-plugin for Crankshaft.


## Checklist:

### Developer Checklist

- [x] I am the original author or an authorized maintainer of this plugin.
- [x] I have abided by the licenses of the libraries I am utilizing, including attaching license notices where appropriate.

### Plugin Checklist

- [x] I have verified that my plugin works properly on the Stable and Beta update channels of SteamOS.
- [x] I have verified my plugin is unique or alternatively provides more/alternative functionality to a similar plugin already on the store.

### Plugin Backend Checklist

- **No**: I am using a custom backend other than Python.
 Note: The original gst-launcher-1.0 from SteamOS (which is called through Python) is used, but requires extra dependencies, which are downloaded in the build process in through the Holo-Base-Docker-Container. Also in the build process through pip psutil is downloaded
- **No**: I am using a tool or software from a 3rd party FOSS project that does not have it's dependencies [statically linked](https://en.wikipedia.org/wiki/Static_library).
- **No**: I am using a custom binary that has all of it's dependencies statically linked.

<!-- The following section is for testers and maintainers, please do not modify it unless you don't meet the criteria for testing on the preview channel. -->

## Testing

- [x] Tested on SteamOS Stable Update Channel.
<!-- Leave me be unless you don't need preview testing, I just make the buttons look nice -->
- [x] Tested on SteamOS Beta Update Channel.
<!-- If you answered "No" to all of the Plugin Backend Checklist then you may remove the below line for testing on preview channel. -->
- [ ] Tested on SteamOS Preview Update Channel.
