### PR TITLE
Added volume-boost 0.0.2

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -130,3 +130,6 @@
 [submodule "plugins/MangoPeel"]
 	path = plugins/MangoPeel
 	url = https://github.com/Gawah/MangoPeel
+[submodule "plugins/volume-boost"]
+	path = plugins/volume-boost
+	url = https://github.com/saumya-banthia/volume-boost


### PR DESCRIPTION
<!-- Make sure to include your plugin name below! -->

# Volume Boost

A Decky plugin to boost default audio device volume to greater than 100% (upto 150%).

## Checklist:

### Developer Checklist

- [x] I am the original author or an authorized maintainer of this plugin.
- [x] I have abided by the licenses of the libraries I am utilizing, including attaching license notices where appropriate.

### Plugin Checklist

- [x] I have verified that my plugin works properly on the Stable and Beta update channels of SteamOS.
- [x] I have verified my plugin is unique or alternatively provides more/alternative functionality to a similar plugin already on the store.

<!-- The following section needs to be modified as yes/no answers by the plugin developer. -->

<!-- Ex: "**Yes/No**: ..." becomes "**Yes**: ..." -->

### Plugin Backend Checklist

- **No**: I am using a custom backend other than Python.
- **No**: I am using a tool or software from a 3rd party FOSS project that does not have it's dependencies [statically linked](https://en.wikipedia.org/wiki/Static_library).
- **No**: I am using a custom binary that has all of it's dependencies statically linked.

<!-- The following section is should be modified to fit the conditions for plugin testing found here: https://wiki.deckbrew.xyz/en/plugin-dev/review-and-testing -->

## Testing

<!-- Remove this box for SteamOS Stable/Beta testing if you use a custom or remote binary, for more info follow the URL in the comment above the testing section. -->
- [ ] Tested on SteamOS Stable/Beta Update Channel.