### PR TITLE
Add Free Loader v1.0.0

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -139,3 +139,6 @@
 [submodule "plugins/DeckWebBrowser"]
 	path = plugins/DeckWebBrowser
 	url = https://github.com/jessebofill/DeckWebBrowser.git
+[submodule "plugins/free-loader"]
+	path = plugins/free-loader
+	url = https://github.com/jwhitlow45/free-loader


### PR DESCRIPTION
# Free Loader

A plugin to provide notifications for and easy access to free games on the Steam store. Includes a page with a list of games which all link to their respective Steam store pages, and user settings for how often to check for new games as well as a notification toggle.

## Checklist:

### Developer Checklist

- [x] I am the original author or an authorized maintainer of this plugin.
- [x] I have abided by the licenses of the libraries I am utilizing, including attaching license notices where appropriate.

### Plugin Checklist

- [x] I have verified that my plugin works properly on the Stable and Beta update channels of SteamOS.
- [x] I have verified my plugin is unique or alternatively provides more/alternative functionality to a similar plugin already on the store.

### Plugin Backend Checklist

- **No**: I am using a custom backend other than Python.
- **No**: I am using a tool or software from a 3rd party FOSS project that does not have it's dependencies [statically linked](https://en.wikipedia.org/wiki/Static_library).
- **No**: I am using a custom binary that has all of it's dependencies statically linked.

## Testing

- [ ] Tested on SteamOS Stable/Beta Update Channel.
