### PR TITLE
Add DeckyFileServer

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -142,3 +142,6 @@
 [submodule "plugins/DeckWebBrowser"]
 	path = plugins/DeckWebBrowser
 	url = https://github.com/jessebofill/DeckWebBrowser.git
+[submodule "plugins/DeckyFileServer"]
+	path = plugins/DeckyFileServer
+	url = https://github.com/grimkor/DeckyFileServer


### PR DESCRIPTION
# DeckyFileServer

A decky plugin that allows you to quickly browse to files on your steam deck from a browser on another device.

## Checklist:

### Developer Checklist

- [x] I am the original author or an authorized maintainer of this plugin.
- [x] I have abided by the licenses of the libraries I am utilizing, including attaching license notices where appropriate.

### Plugin Checklist

- [x] I have verified that my plugin works properly on the Stable and Beta update channels of SteamOS.
- [x] I have verified my plugin is unique or alternatively provides more/alternative functionality to a similar plugin already on the store.


### Plugin Backend Checklist

- **No**: I am using a custom backend other than Python.
- **No**: I am using a tool or software from a 3rd party FOSS project that does not have it's dependencies [statically linked](https://en.wikipedia.org/wiki/Static_library).
- **No**: I am using a custom binary that has all of it's dependencies statically linked.


## Testing

- [ ] Tested on SteamOS Stable/Beta Update Channel.
