### PR TITLE
[Postpone] Add decky-addtosteam v1.0.0

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -145,3 +145,6 @@
 [submodule "plugins/DeckyFileServer"]
 	path = plugins/DeckyFileServer
 	url = https://github.com/grimkor/DeckyFileServer
+[submodule "plugins/decky-addtosteam"]
+	path = plugins/decky-addtosteam
+	url = https://github.com/jurassicplayer/decky-addtosteam.git


### PR DESCRIPTION
# Add to Steam v1.0.0

A simple plugin to add Steam shortcuts to files from GameMode. Relies on the deckyloader openFilePickerV2, so testing needs to be done with decky-loader v2.10.3-pre1+
- edit -
Apparently there is Quick Launch plugin that provides similar functionality and has a nicer interface, but no simple file picker shortcut creation. Asked developer of QuickLaunch to re-implement/integrate into their plugin, so delay/close this once QuickLaunch gets updated.

## Checklist:

### Developer Checklist

- [x] I am the original author or an authorized maintainer of this plugin.
- [x] I have abided by the licenses of the libraries I am utilizing, including attaching license notices where appropriate.

### Plugin Checklist

- [x] I have verified that my plugin works properly on the Stable and Beta update channels of SteamOS.
- [x] I have verified my plugin is unique or alternatively provides more/alternative functionality to a similar plugin already on the store.

### Plugin Backend Checklist

- **No**: I am using a custom backend other than Python.
- **No**: I am using a tool or software from a 3rd party FOSS project that does not have it's dependencies [statically linked](https://en.wikipedia.org/wiki/Static_library).
- **No**: I am using a custom binary that has all of it's dependencies statically linked.

## Testing
- [ ] Tested on SteamOS Stable/Beta Update Channel.