### PR TITLE
Add decky-syncthing

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -151,3 +151,6 @@
 [submodule "plugins/radiyo-steam-deck"]
 	path = plugins/radiyo-steam-deck
 	url = https://github.com/isiah-lloyd/radiyo-steam-deck
+[submodule "plugins/decky-syncthing"]
+	path = plugins/decky-syncthing
+	url = https://github.com/theCapypara/steamdeck-decky-syncthing.git


### PR DESCRIPTION
<!-- Make sure to include your plugin name below! -->

# decky-syncthing (Syncthing)

> Plugin for managing Syncthing to synchronize files with other devices. Not officially affiliated with the Syncthing project.

From the README:

> A [Decky](https://decky.xyz/) plugin to manage [Syncthing](https://syncthing.net/) from your Steam Deck.
>
> This plugin allows you to start and stop Syncthing from the Quick Access panel of your Steam Deck.
>
> It also has some basic stats and allows you to access the web UI. It can also be configured to automatically start Syncthing with Gamescope (the Steam Deck main UI).
>
> The plugin works no matter if you have HTTPS enabled or not and also no matter if you have basic auth enabled.
>
> Since the Steam Deck UI has no support for self-signed HTTPS certificates or Basic Auth, this plugin starts a proxy server on port 58384 (HTTP, localhost only) that forwards requests to the Syncthing Web UI and API. 

![Screenshot of the plugin](https://raw.githubusercontent.com/theCapypara/steamdeck-decky-syncthing/main/banner.png)

**NOTE: This PR template contained a link asking me to review https://deckbrew.xyz/en/plugin-dev/review-and-testing - this page does not exist! So I did not review that page.**

## Checklist:

### Developer Checklist

- [X] I am the original author or an authorized maintainer of this plugin.
- [X] I have abided by the licenses of the libraries I am utilizing, including attaching license notices where appropriate.

### Plugin Checklist

- [X] I have verified that my plugin works properly on the Stable and Beta update channels of SteamOS.
- [X] I have verified my plugin is unique or alternatively provides more/alternative functionality to a similar plugin already on the store.

### Plugin Backend Checklist

- **Yes**: I am using a custom backend other than Python.
- **Yes**: I am using a tool or software from a 3rd party FOSS project that does not have it's dependencies [statically linked](https://en.wikipedia.org/wiki/Static_library).
- **No**: I am using a custom binary that has all of it's dependencies statically linked.

The Rust backend is mostly statically linked but does rely on some very standard system libs like OpenSSL 1.1.

## Testing

- [ ] Tested on SteamOS Preview Update Channel.
