### PR TITLE
Add Decky Terminal

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -163,3 +163,6 @@
 [submodule "plugins/sharedeck-y"]
 	path = plugins/sharedeck-y
 	url = git@github.com:davocarli/sharedeck-y.git
+[submodule "plugins/decky-terminal"]
+	path = plugins/decky-terminal
+	url = https://github.com/Alex4386/decky-terminal


### PR DESCRIPTION
<!-- Make sure to include your plugin name below! -->

# Decky Terminal
This plugin adds missing terminal emulator in game-mode. providing access to terminal while playing games.  

## Checklist:

### Developer Checklist

- [X] I am the original author or an authorized maintainer of this plugin.
- [X] I have abided by the licenses of the libraries I am utilizing, including attaching license notices where appropriate.

### Plugin Checklist

- [X] I have verified that my plugin works properly on the Stable and Beta update channels of SteamOS.
- [X] I have verified my plugin is unique or alternatively provides more/alternative functionality to a similar plugin already on the store.

### Plugin Backend Checklist

- **No**: I am using a custom backend other than Python.
- **No**: I am using a tool or software from a 3rd party FOSS project that does not have it's dependencies [statically linked](https://en.wikipedia.org/wiki/Static_library).
- **No**: I am using a custom binary that has all of it's dependencies statically linked.

<!-- The following section is should be modified to fit the conditions for plugin testing found here: https://wiki.deckbrew.xyz/en/plugin-dev/review-and-testing -->

## Testing

<!-- Remove this box for SteamOS Stable/Beta testing if you use a custom or remote binary, for more info follow the URL in the comment above the testing section. -->
- [X] Tested on SteamOS Stable/Beta Update Channel.
