### PR TITLE
Change recorder to my fork, fix breakage caused by recent Decky changes

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -98,8 +98,8 @@
 	url = https://github.com/dafta/DeckMTP
 [submodule "plugins/decky-recorder"]
 	path = plugins/decky-recorder
-	url = https://github.com/marissa999/decky-recorder.git
-	branch = main-0.2.1
+	url = https://github.com/safijari/decky-recorder.git
+	branch = main
 [submodule "plugins/Steamback"]
 	path = plugins/Steamback
 	url = https://github.com/geeksville/steamback.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -98,8 +98,7 @@
 	url = https://github.com/dafta/DeckMTP
 [submodule "plugins/decky-recorder"]
 	path = plugins/decky-recorder
-	url = https://github.com/safijari/decky-recorder.git
-	branch = main
+	url = https://github.com/safijari/decky-recorder-fork.git
 [submodule "plugins/Steamback"]
 	path = plugins/Steamback
 	url = https://github.com/geeksville/steamback.git


### PR DESCRIPTION
# Decky Recorder
Records games.

I'm requesting that we change the plugin over to my fork which is currently maintained. It contains fixes for some common bugs as well as a recent breakage caused by 2.10.4 (see discussion here https://github.com/marissa999/decky-recorder/issues/65).

## Checklist:

### Developer Checklist

- [X] I am the original author or an authorized maintainer of this plugin.
- [X] I have abided by the licenses of the libraries I am utilizing, including attaching license notices where appropriate.

### Plugin Checklist

- [X] I have verified that my plugin works properly on the Stable and Beta update channels of SteamOS.
- [X] I have verified my plugin is unique or alternatively provides more/alternative functionality to a similar plugin already on the store.

<!-- The following section needs to be modified as yes/no answers by the plugin developer. -->

<!-- Ex: "**Yes/No**: ..." becomes "**Yes**: ..." -->

### Plugin Backend Checklist

- **No**: I am using a custom backend other than Python.
- **No**: I am using a tool or software from a 3rd party FOSS project that does not have it's dependencies [statically linked](https://en.wikipedia.org/wiki/Static_library).
- **No**: I am using a custom binary that has all of it's dependencies statically linked.

<!-- The following section is should be modified to fit the conditions for plugin testing found here: https://wiki.deckbrew.xyz/en/plugin-dev/review-and-testing -->

## Testing

<!-- Remove this box for SteamOS Stable/Beta testing if you use a custom or remote binary, for more info follow the URL in the comment above the testing section. -->
- [ ] Tested on SteamOS Stable/Beta Update Channel.
