### PR TITLE
Update DeckyTerminal to v0.3.0

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -163,3 +163,6 @@
 [submodule "plugins/sharedeck-y"]
 	path = plugins/sharedeck-y
 	url = git@github.com:davocarli/sharedeck-y.git
+[submodule "plugins/decky-terminal"]
+	path = plugins/decky-terminal
+	url = https://github.com/Alex4386/decky-terminal


### PR DESCRIPTION
<!-- Make sure to include your plugin name below! -->

# Decky Terminal
This plugin adds missing terminal emulator in game-mode. providing access to terminal while playing games.  

## Changelog
### What's new on v0.3.0:  
* Fixed `Default Shell` bug reported at https://github.com/SteamDeckHomebrew/decky-plugin-database/pull/426#pullrequestreview-1597743905.
* Added `Handheld Mode` to add Virtual Keyboard padding under the terminal, preventing terminal contents hiding behind the virtual keyboard.

For more information, Please check the changelog available at:  
* [https://github.com/Alex4386/decky-terminal/releases/tag/v0.3.0](https://github.com/Alex4386/decky-terminal/releases/tag/v0.3.0)

## Checklist:

### Developer Checklist

- [X] I am the original author or an authorized maintainer of this plugin.
- [X] I have abided by the licenses of the libraries I am utilizing, including attaching license notices where appropriate.

### Plugin Checklist

- [X] I have verified that my plugin works properly on the Stable and Beta update channels of SteamOS.
- [X] I have verified my plugin is unique or alternatively provides more/alternative functionality to a similar plugin already on the store.

### Plugin Backend Checklist

- **No**: I am using a custom backend other than Python.
- **No**: I am using a tool or software from a 3rd party FOSS project that does not have it's dependencies [statically linked](https://en.wikipedia.org/wiki/Static_library).
- **No**: I am using a custom binary that has all of it's dependencies statically linked.
