### PR TITLE
add DeckScreenshotManager

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -180,3 +180,6 @@
 [submodule "plugins/decky-xrealAir"]
 	path = plugins/decky-xrealAir
 	url = https://github.com/wheaney/decky-xrealAir.git
+[submodule "plugins/DeckScreenshotManager"]
+	path = plugins/DeckScreenshotManager
+	url = https://github.com/codehz/DeckScreenshotManager


### PR DESCRIPTION
<!-- Make sure to include your plugin name below! -->

# Screenshot Uploader

Valve does not implement auto-upload screenshot for us, so I added it.

See: https://steamcommunity.com/app/1675200/discussions/2/6117591738155117046/

It is a simple plugin, no custom backend code is needed, all functionality is implemented in js (except for saving/loading setting, which is implemented in python), reuse SteamClient API.

Do not confuse with the Shotty plugin, since it is used to link screenshot to Picture folder.

## Checklist:

### Developer Checklist

- [x] I am the original author or an authorized maintainer of this plugin.
- [x] I have abided by the licenses of the libraries I am utilizing, including attaching license notices where appropriate.

### Plugin Checklist

- [x] I have verified that my plugin works properly on the Stable and Beta update channels of SteamOS.
- [x] I have verified my plugin is unique or alternatively provides more/alternative functionality to a similar plugin already on the store.

<!-- The following section needs to be modified as yes/no answers by the plugin developer. -->

<!-- Ex: "**Yes/No**: ..." becomes "**Yes**: ..." -->

### Plugin Backend Checklist

- **No**: I am using a custom backend other than Python.
- **No**: I am using a tool or software from a 3rd party FOSS project that does not have it's dependencies [statically linked](https://en.wikipedia.org/wiki/Static_library).
- **No**: I am using a custom binary that has all of it's dependencies statically linked.

<!-- The following section is should be modified to fit the conditions for plugin testing found here: https://wiki.deckbrew.xyz/en/plugin-dev/review-and-testing -->

## Testing

<!-- Remove this box for SteamOS Stable/Beta testing if you use a custom or remote binary, for more info follow the URL in the comment above the testing section. -->
- [ ] Tested on SteamOS Stable/Beta Update Channel.
