### PR TITLE
[WIP] Add DisplayOverclock

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -180,3 +180,6 @@
 [submodule "plugins/decky-xrealAir"]
 	path = plugins/decky-xrealAir
 	url = https://github.com/wheaney/decky-xrealAir.git
+[submodule "plugins/DisplayOverclock"]
+	path = plugins/DisplayOverclock
+	url = https://git.catvibers.me/aa/DisplayOverclock.git


### PR DESCRIPTION
<!-- Make sure to include your plugin name below! -->

# DisplayOverclock

This plugin allows you to overclock your Steam Deck internal display to up to 70hz using the built in but currently disabled display overclocking feature in yesterday's Steam Client Beta.

## Checklist:

### Developer Checklist

- [x] I am the original author or an authorized maintainer of this plugin.
- [x] I have abided by the licenses of the libraries I am utilizing, including attaching license notices where appropriate.

### Plugin Checklist

- [x] I have verified that my plugin works properly on the Stable and Beta update channels of SteamOS.
	- This plugin cannot work on Stable currently, and will detect the Steam Client version and show a modal if it is too old.
- [x] I have verified my plugin is unique or alternatively provides more/alternative functionality to a similar plugin already on the store.

<!-- The following section needs to be modified as yes/no answers by the plugin developer. -->

<!-- Ex: "**Yes/No**: ..." becomes "**Yes**: ..." -->

### Plugin Backend Checklist

- **No**: I am using a custom backend other than Python.
- **No**: I am using a tool or software from a 3rd party FOSS project that does not have it's dependencies [statically linked](https://en.wikipedia.org/wiki/Static_library).
- **No**: I am using a custom binary that has all of it's dependencies statically linked.

<!-- The following section is should be modified to fit the conditions for plugin testing found here: https://wiki.deckbrew.xyz/en/plugin-dev/review-and-testing -->

## Testing

<!-- Remove this box for SteamOS Stable/Beta testing if you use a custom or remote binary, for more info follow the URL in the comment above the testing section. -->
- [ ] Tested on SteamOS Stable/Beta Update Channel.
