### PR TITLE
Add Decky Custom Runner v0.0.2

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -163,3 +163,6 @@
 [submodule "plugins/sharedeck-y"]
 	path = plugins/sharedeck-y
 	url = git@github.com:davocarli/sharedeck-y.git
+[submodule "plugins/decky-terminal"]
+	path = plugins/decky-terminal
+	url = https://github.com/Alex4386/decky-terminal

--- a/.gitmodules
+++ b/.gitmodules
@@ -189,3 +189,6 @@
 [submodule "plugins/decky-save-manager"]
 	path = plugins/decky-save-manager
 	url = https://github.com/metehankutlu/decky-save-manager
+[submodule "plugins/decky-custom-runner"]
+	path = plugins/decky-custom-runner
+	url = https://github.com/Alex4386/decky-custom-runner


### PR DESCRIPTION
<!-- Make sure to include your plugin name below! -->

# Decky Custom Runner
This plugin allows you to run the other binaries inside the game installation both inside and outside of the game's proton environment, allowing you to launch game launchers (such as: rockstar social club) inside game-mode. [Repository](https://github.com/Alex4386/decky-custom-runner)

## Checklist:

### Developer Checklist

- [X] I am the original author or an authorized maintainer of this plugin.
- [X] I have abided by the licenses of the libraries I am utilizing, including attaching license notices where appropriate.

### Plugin Checklist

- [X] I have verified that my plugin works properly on the Stable and Beta update channels of SteamOS.
- [X] I have verified my plugin is unique or alternatively provides more/alternative functionality to a similar plugin already on the store.

<!-- The following section needs to be modified as yes/no answers by the plugin developer. -->

<!-- Ex: "**Yes/No**: ..." becomes "**Yes**: ..." -->

### Plugin Backend Checklist

- **No**: I am using a custom backend other than Python.
- **No**: I am using a tool or software from a 3rd party FOSS project that does not have it's dependencies [statically linked](https://en.wikipedia.org/wiki/Static_library).
- **No**: I am using a custom binary that has all of it's dependencies statically linked.

## Testing
- [ ] Tested on SteamOS Stable/Beta Update Channel.

