### PR TITLE
Add kdeconnect plugin

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -195,3 +195,6 @@
 [submodule "plugins/CheatDeck"]
 	path = plugins/CheatDeck
 	url = https://github.com/SheffeyG/CheatDeck
+[submodule "plugins/kdeconnect"]
+	path = plugins/kdeconnect
+	url = https://github.com/safijari/Decky-KDE-Connect.git


### PR DESCRIPTION
<!-- Make sure to include your plugin name below! -->

# KDE Connect
When enabled, the plugin manages bringing up kdeconnect and switching over to a different instance of kdeconnect when going between the main UI and a game (because gamescope's use of xwayland is special). With this plugin basic keyboard and mouse input from kdeconnect is now possible in gamemode without any extra effort. Audio can also be adjusted. 

## Checklist:

### Developer Checklist

- [X] I am the original author or an authorized maintainer of this plugin.
- [X] I have abided by the licenses of the libraries I am utilizing, including attaching license notices where appropriate.

### Plugin Checklist

- [X] I have verified that my plugin works properly on the Stable and Beta update channels of SteamOS.
- [X] I have verified my plugin is unique or alternatively provides more/alternative functionality to a similar plugin already on the store.

### Plugin Backend Checklist

- **No**: I am using a custom backend other than Python.
- **No**: I am using a tool or software from a 3rd party FOSS project that does not have it's dependencies [statically linked](https://en.wikipedia.org/wiki/Static_library).
- **No**: I am using a custom binary that has all of it's dependencies statically linked.

<!-- The following section is should be modified to fit the conditions for plugin testing found here: https://wiki.deckbrew.xyz/en/plugin-dev/review-and-testing -->

## Testing

<!-- Remove this box for SteamOS Stable/Beta testing if you use a custom or remote binary, for more info follow the URL in the comment above the testing section. -->
- [ ] Tested on SteamOS Stable/Beta Update Channel.