### PR TITLE
Add reshadeck plugin

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -195,3 +195,6 @@
 [submodule "plugins/CheatDeck"]
 	path = plugins/CheatDeck
 	url = https://github.com/SheffeyG/CheatDeck
+[submodule "plugins/reshadeck"]
+	path = plugins/reshadeck
+	url = https://github.com/safijari/reshadeck


### PR DESCRIPTION
<!-- Make sure to include your plugin name below! -->

# Reshadeck
The plugin provides a way to load reshade shaders. It ships with 3 curated plugins (one of which can [reverse the fringing patterns on the OLED steam deck](https://gist.github.com/safijari/1b936cbbdebe341fbe340bcfecb04450)). Users can add more by following the instructions in the plugin.

## Checklist:

### Developer Checklist

- [X] I am the original author or an authorized maintainer of this plugin.
- [X] I have abided by the licenses of the libraries I am utilizing, including attaching license notices where appropriate.

### Plugin Checklist

- [X] I have verified that my plugin works properly on the Stable and Beta update channels of SteamOS.
- [X] I have verified my plugin is unique or alternatively provides more/alternative functionality to a similar plugin already on the store.

<!-- The following section needs to be modified as yes/no answers by the plugin developer. -->

<!-- Ex: "**Yes/No**: ..." becomes "**Yes**: ..." -->

### Plugin Backend Checklist

- **No**: I am using a custom backend other than Python.
- **No**: I am using a tool or software from a 3rd party FOSS project that does not have it's dependencies [statically linked](https://en.wikipedia.org/wiki/Static_library).
- **No**: I am using a custom binary that has all of it's dependencies statically linked.

<!-- The following section is should be modified to fit the conditions for plugin testing found here: https://wiki.deckbrew.xyz/en/plugin-dev/review-and-testing -->

## Testing

<!-- Remove this box for SteamOS Stable/Beta testing if you use a custom or remote binary, for more info follow the URL in the comment above the testing section. -->
- [x] Tested on SteamOS Stable/Beta Update Channel.
