### PR TITLE
Add BT Wake Control v1.0.0

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -205,3 +205,6 @@
 [submodule "plugins/decky-XRGaming"]
 	path = plugins/decky-XRGaming
 	url = git@github.com:wheaney/decky-XRGaming.git
+[submodule "plugins/decky-bluetooth-wake-control"]
+	path = plugins/decky-bluetooth-wake-control
+	url = https://gitlab.com/finewolf-projects/decky-plugin-bluetooth-wake-control.git


### PR DESCRIPTION
# BT Wake Control

Allows to selectively disable and/or enable Wake-on-Bluetooth capabilities for your Bluetooth devices.

This is a Decky Plugin version of my ["Wake-on-Bluetooth Settings"](https://gitlab.com/finewolf-projects/steamos-helpers/-/tree/master/wake-on-bluetooth-settings) script that does the same thing.

![BT Wake Control Screenshot](https://gitlab.com/finewolf-projects/decky-plugin-bluetooth-wake-control/-/raw/master/.docs/assets/Screenshot.png)

## Checklist:

### Developer Checklist

- [X] I am the original author or an authorized maintainer of this plugin.
- [X] I have abided by the licenses of the libraries I am utilizing, including attaching license notices where appropriate.
  - (This plugin did not use the plugin template)

### Plugin Checklist

- [X] I have verified that my plugin works properly on the Stable and Beta update channels of SteamOS.
- [X] I have verified my plugin is unique or alternatively provides more/alternative functionality to a similar plugin already on the store.

<!-- The following section needs to be modified as yes/no answers by the plugin developer. -->

<!-- Ex: "**Yes/No**: ..." becomes "**Yes**: ..." -->

### Plugin Backend Checklist

- **No**: I am using a custom backend other than Python.
- **No**: I am using a tool or software from a 3rd party FOSS project that does not have it's dependencies [statically linked](https://en.wikipedia.org/wiki/Static_library).
- **No**: I am using a custom binary that has all of it's dependencies statically linked.

<!-- The following section is should be modified to fit the conditions for plugin testing found here: https://wiki.deckbrew.xyz/en/plugin-dev/review-and-testing -->

## Testing

<!-- Remove this box for SteamOS Stable/Beta testing if you use a custom or remote binary, for more info follow the URL in the comment above the testing section. -->
- [ ] Tested on SteamOS Stable/Beta Update Channel.

## Additional Testing Note

Since the original LED Steam Deck does not support WoB (Wake-on-Bluetooth), the plugin displays a static notice on one of these models (the original LED Steam Deck and the revised cooler design one).