### PR TITLE
Fix URL for decky-XRGaming so it doesn't require ssh

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -200,7 +200,7 @@
 	url = https://github.com/safijari/Decky-KDE-Connect.git
 [submodule "plugins/decky-XRGaming"]
 	path = plugins/decky-XRGaming
-	url = git@github.com:wheaney/decky-XRGaming.git
+	url = https://github.com/wheaney/decky-XRGaming.git
 [submodule "plugins/decky-bluetooth-wake-control"]
 	path = plugins/decky-bluetooth-wake-control
 	url = https://gitlab.com/finewolf-projects/decky-plugin-bluetooth-wake-control.git


### PR DESCRIPTION
The changes here fix the root cause of the build failure in [this PR](https://github.com/SteamDeckHomebrew/decky-plugin-database/actions/runs/7983406773). No changes to the plugin itself.

The issue was that the docker build's `entrypoint.sh` was cloning my decky repo to attempt to download and verify the remote binaries, but it was checking out the latest version of my repo, not the one in the plugin-database. This change makes it so it checks out the plugin-database package, then the committed version of my submodule so it's not getting ahead of the approved version.