### PR TITLE
Add GameAssistSteamOS

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -204,3 +204,6 @@
 [submodule "plugins/decky-bluetooth-wake-control"]
 	path = plugins/decky-bluetooth-wake-control
 	url = https://gitlab.com/finewolf-projects/decky-plugin-bluetooth-wake-control.git
+[submodule "plugins/GameAssistSteamOS"]
+	path = plugins/GameAssistSteamOS
+	url = https://github.com/TeslaKang/GameAssistSteamOS.git


### PR DESCRIPTION
<!-- Make sure to include your plugin name below! -->

# GameAssist
This program supports TDP settings, FAN control, BASH commands, etc. on Steam OS(gamescope-session) installed on general UMPC with KDE Arch Linux.

## Checklist:

### Developer Checklist

- [x] I am the original author or an authorized maintainer of this plugin.
- [x] I have abided by the licenses of the libraries I am utilizing, including attaching license notices where appropriate.

### Plugin Checklist

- [x] I have verified that my plugin works properly on gamescope-session(https://github.com/TeslaKang/gamescope-session)
- [x] I have verified my plugin is unique or alternatively provides more/alternative functionality to a similar plugin already on the store.

### Plugin Backend Checklist

- **No**: I am using a custom backend other than Python.
- **No**: I am using a tool or software from a 3rd party FOSS project that does not have it's dependencies [statically linked](https://en.wikipedia.org/wiki/Static_library).
- **No**: I am using a custom binary that has all of it's dependencies statically linked.

## Testing
- [ ] Only work KDE Arch linux(I recommend a minimum version of Manjaro Linux KDE) with my gamescope-session(https://github.com/TeslaKang/gamescope-session).
