### PR TITLE
Add VirtualHere plugin

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -204,3 +204,6 @@
 [submodule "plugins/decky-bluetooth-wake-control"]
 	path = plugins/decky-bluetooth-wake-control
 	url = https://gitlab.com/finewolf-projects/decky-plugin-bluetooth-wake-control.git
+[submodule "plugins/VirtualHere"]
+	path = plugins/VirtualHere
+	url = https://github.com/safijari/VirtualHere


### PR DESCRIPTION
<!-- Make sure to include your plugin name below! -->

# VirtualHere

Simple plugin to run virtualhere on the Steam Deck and share the Deck's controller (or other peripherals) with another machine. Great for using the Deck as a separate controller or being able to use moonlight with certain games where VigEm gets flagged by the anticheat.

Note: When the Deck controller is connected to another device it won't be available to the Deck itself. This plugin makes it so that you can open the Quick Access Menu by hitting both volume buttons together. This will allow you to go to the plugin page again and disable it which will reconnect the Deck controller back to the Deck.

## Checklist:

### Developer Checklist

- [X] I am the original author or an authorized maintainer of this plugin.
(Not sure what to do about below since I'm vendoring the server binary)
- [ ] I have abided by the licenses of the libraries I am utilizing, including attaching license notices where appropriate.

### Plugin Checklist

- [X] I have verified that my plugin works properly on the Stable and Beta update channels of SteamOS.
- [X] I have verified my plugin is unique or alternatively provides more/alternative functionality to a similar plugin already on the store.

<!-- The following section needs to be modified as yes/no answers by the plugin developer. -->

<!-- Ex: "**Yes/No**: ..." becomes "**Yes**: ..." -->

### Plugin Backend Checklist

- **No**: I am using a custom backend other than Python.
- **No**: I am using a tool or software from a 3rd party FOSS project that does not have it's dependencies [statically linked](https://en.wikipedia.org/wiki/Static_library).
- **Yes**: I am using a custom binary that has all of it's dependencies statically linked.

<!-- The following section is should be modified to fit the conditions for plugin testing found here: https://wiki.deckbrew.xyz/en/plugin-dev/review-and-testing -->

## Testing

<!-- Remove this box for SteamOS Stable/Beta testing if you use a custom or remote binary, for more info follow the URL in the comment above the testing section. -->
- [ ] Tested on SteamOS Stable/Beta Update Channel.

<!-- Remove this box for SteamOS Preview testing if you do not use a custom or remote binary, for more info follow the URL in the comment above the testing section. -->
- [ ] Tested on SteamOS Preview Update Channel.
