### PR TITLE
Add Decky Brightness Bar

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -204,3 +204,6 @@
 [submodule "plugins/decky-bluetooth-wake-control"]
 	path = plugins/decky-bluetooth-wake-control
 	url = https://gitlab.com/finewolf-projects/decky-plugin-bluetooth-wake-control.git
+[submodule "plugins/decky-brightness-bar"]
+	path = plugins/decky-brightness-bar
+	url = https://github.com/rasitayaz/decky-brightness-bar


### PR DESCRIPTION
# Decky Brightness Bar

Displays a customizable brightness bar when the brightness is changed with 'STEAM/QAM + LS up/down' shortcuts.

Repository: https://github.com/rasitayaz/decky-brightness-bar

![](https://raw.githubusercontent.com/rasitayaz/decky-brightness-bar/main/preview.jpg)

## Checklist:

### Developer Checklist

- [x] I am the original author or an authorized maintainer of this plugin.
- [x] I have abided by the licenses of the libraries I am utilizing, including attaching license notices where appropriate.

### Plugin Checklist

- [x] I have verified that my plugin works properly on the Stable and Beta update channels of SteamOS.
- [x] I have verified my plugin is unique or alternatively provides more/alternative functionality to a similar plugin already on the store.

### Plugin Backend Checklist

- **No**: I am using a custom backend other than Python.
- **No**: I am using a tool or software from a 3rd party FOSS project that does not have it's dependencies [statically linked](https://en.wikipedia.org/wiki/Static_library).
- **No**: I am using a custom binary that has all of it's dependencies statically linked.

<!-- The following section is should be modified to fit the conditions for plugin testing found here: https://wiki.deckbrew.xyz/en/plugin-dev/review-and-testing -->

## Testing

<!-- Remove this box for SteamOS Stable/Beta testing if you use a custom or remote binary, for more info follow the URL in the comment above the testing section. -->
- [ ] Tested on SteamOS Stable/Beta Update Channel.