### PR TITLE
Added MagicBlack plugin

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -204,3 +204,6 @@
 [submodule "plugins/decky-bluetooth-wake-control"]
 	path = plugins/decky-bluetooth-wake-control
 	url = https://gitlab.com/finewolf-projects/decky-plugin-bluetooth-wake-control.git
+[submodule "plugins/MagicBlackDecky"]
+	path = plugins/MagicBlackDecky
+	url = https://github.com/steam3d/MagicBlackDecky.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -204,12 +204,12 @@
 [submodule "plugins/decky-bluetooth-wake-control"]
 	path = plugins/decky-bluetooth-wake-control
 	url = https://gitlab.com/finewolf-projects/decky-plugin-bluetooth-wake-control.git
-[submodule "plugins/MagicBlackDecky"]
-	path = plugins/MagicBlackDecky
-	url = https://github.com/steam3d/MagicBlackDecky.git
 [submodule "plugins/decky-brightness-bar"]
 	path = plugins/decky-brightness-bar
 	url = https://github.com/rasitayaz/decky-brightness-bar
 [submodule "plugins/decky-notifications"]
 	path = plugins/decky-notifications
 	url = https://github.com/Firemoon777/decky-notifications
+[submodule "plugins/MagicBlackDecky"]
+	path = plugins/MagicBlackDecky
+	url = https://github.com/steam3d/MagicBlackDecky.git


### PR DESCRIPTION
<!-- Make sure to include your plugin name below! -->

# MagicBlack

Overlays the screen with black color using shortcut, emulating the screen being turned off on the Steam Deck OLED.

## Checklist:

### Developer Checklist

- [x] I am the original author or an authorized maintainer of this plugin.
- [x] I have abided by the licenses of the libraries I am utilizing, including attaching license notices where appropriate.

### Plugin Checklist

- [x] I have verified that my plugin works properly on the Stable and Beta update channels of SteamOS.
- [x] I have verified my plugin is unique or alternatively provides more/alternative functionality to a similar plugin already on the store.

<!-- The following section needs to be modified as yes/no answers by the plugin developer. -->

<!-- Ex: "**Yes/No**: ..." becomes "**Yes**: ..." -->

### Plugin Backend Checklist

- **No**: I am using a custom backend other than Python.
- **No**: I am using a tool or software from a 3rd party FOSS project that does not have it's dependencies [statically linked](https://en.wikipedia.org/wiki/Static_library).
- **No**: I am using a custom binary that has all of it's dependencies statically linked.

<!-- The following section is should be modified to fit the conditions for plugin testing found here: https://wiki.deckbrew.xyz/en/plugin-dev/review-and-testing -->

## Testing

<!-- Remove this box for SteamOS Stable/Beta testing if you use a custom or remote binary, for more info follow the URL in the comment above the testing section. -->
- [x] Tested on SteamOS Stable/Beta Update Channel.
