### PR TITLE
Add DeckShare Plugin v0.2.0

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -215,4 +215,4 @@
 	url = https://github.com/steam3d/MagicBlackDecky.git
 [submodule "plugins/DeckShare-DeckyPlugin"]
 	path = plugins/DeckShare-DeckyPlugin
-	url = https://github.com/smugzombie/DeckShare-DeckyPlugin.git
+	url = https://github.com/SmugZombie/DeckShare-DeckyPlugin.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -213,3 +213,6 @@
 [submodule "plugins/MagicBlackDecky"]
 	path = plugins/MagicBlackDecky
 	url = https://github.com/steam3d/MagicBlackDecky.git
+[submodule "plugins/DeckShare-DeckyPlugin"]
+	path = plugins/DeckShare-DeckyPlugin
+	url = https://github.com/smugzombie/DeckShare-DeckyPlugin.git


### PR DESCRIPTION
<!-- Make sure to include your plugin name below! -->

# DeckShare

DeckShare is a simple DeckyLoader plugin that monitors SteamOS for new screenshots using a hook and automatically posts them to Discord via the provided webhook. (You must get your own [Discord webhook](https://support.discord.com/hc/en-us/articles/228383668-Intro-to-Webhooks) url and provide it to the plugin upon first time setup)

## Checklist:

### Developer Checklist

- [X] I am the original author or an authorized maintainer of this plugin.
- [X] I have abided by the licenses of the libraries I am utilizing, including attaching license notices where appropriate.

### Plugin Checklist

- [X] I have verified that my plugin works properly on the Stable and Beta update channels of SteamOS.
- [X] I have verified my plugin is unique or alternatively provides more/alternative functionality to a similar plugin already on the store.

<!-- The following section needs to be modified as yes/no answers by the plugin developer. -->

<!-- Ex: "**Yes/No**: ..." becomes "**Yes**: ..." -->

### Plugin Backend Checklist

- **No**: I am using a custom backend other than Python.
- **No**: I am using a tool or software from a 3rd party FOSS project that does not have it's dependencies [statically linked](https://en.wikipedia.org/wiki/Static_library).
- **No**: I am using a custom binary that has all of it's dependencies statically linked.

<!-- The following section is should be modified to fit the conditions for plugin testing found here: https://wiki.deckbrew.xyz/en/plugin-dev/review-and-testing -->

## Testing
- [X] Tested on SteamOS Stable/Beta Update Channel.

