### PR TITLE
added submodule s0t7x/decky-sunshine

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -213,3 +213,6 @@
 [submodule "plugins/MagicBlackDecky"]
 	path = plugins/MagicBlackDecky
 	url = https://github.com/steam3d/MagicBlackDecky.git
+[submodule "plugins/decky-sunshine"]
+	path = plugins/decky-sunshine
+	url = https://github.com/s0t7x/decky-sunshine.git


### PR DESCRIPTION
<!-- Make sure to include your plugin name below! -->

# Decky Sunshine

Decky Sunshine is a Plugin to easily toggle a [Sunshine Game Streaming Server](https://github.com/LizardByte/Sunshine) and pair devices via PIN. It also checks if Sunshine is already installed or installs it with flatpak. 

## Checklist:

### Developer Checklist

- [X] I am the original author or an authorized maintainer of this plugin.
- [X] I have abided by the licenses of the libraries I am utilizing, including attaching license notices where appropriate.

### Plugin Checklist

- [X] I have verified that my plugin works properly on the Stable and Beta update channels of SteamOS.
- [X] I have verified my plugin is unique or alternatively provides more/alternative functionality to a similar plugin already on the store.

### Plugin Backend Checklist

- **No**: I am using a custom backend other than Python.
- **No**: I am using a tool or software from a 3rd party FOSS project that does not have it's dependencies [statically linked](https://en.wikipedia.org/wiki/Static_library).
- **No**: I am using a custom binary that has all of it's dependencies statically linked.

## Testing

- [X] Tested on SteamOS Stable/Beta Update Channel.
- [X] Tested on SteamOS Preview Update Channel.
