### PR TITLE
add Just Juice plugin

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -225,3 +225,6 @@
 [submodule "plugins/SDH-PauseGames"]
 	path = plugins/SDH-PauseGames
 	url = https://github.com/wynn1212/SDH-PauseGames.git
+[submodule "plugins/decky-just-juice"]
+	path = plugins/decky-just-juice
+	url = git@github.com:bass3l/decky-just-juice.git


### PR DESCRIPTION
<!-- Make sure to include your plugin name below! -->

# Just Juice

Shows the battery icon/percentage in a small manner on the left side of the display screen.

Yes, MangoPeel exists and it's super cool, but I couldn't for the life of me figure out how to only display the battery via the plugin ui :laughing: also you have to be a power user on how MangoHud works to achieve what Just Juice does in a simple click.

![screenshot](https://raw.githubusercontent.com/bass3l/decky-just-juice/master/assets/screenshot-1.png)

## Checklist:

### Developer Checklist

- [X] I am the original author or an authorized maintainer of this plugin.
- [X] I have abided by the licenses of the libraries I am utilizing, including attaching license notices where appropriate.

### Plugin Checklist

- [X] I have verified that my plugin works properly on the Stable and Beta update channels of SteamOS.
- [X] I have verified my plugin is unique or alternatively provides more/alternative functionality to a similar plugin already on the store. `(Kinda? :D)`

<!-- The following section needs to be modified as yes/no answers by the plugin developer. -->

<!-- Ex: "**Yes/No**: ..." becomes "**Yes**: ..." -->

### Plugin Backend Checklist

- **No**: I am using a custom backend other than Python.
- **No**: I am using a tool or software from a 3rd party FOSS project that does not have it's dependencies [statically linked](https://en.wikipedia.org/wiki/Static_library).
- **No**: I am using a custom binary that has all of it's dependencies statically linked.

<!-- The following section is should be modified to fit the conditions for plugin testing found here: https://wiki.deckbrew.xyz/en/plugin-dev/review-and-testing -->

## Testing

<!-- Remove this box for SteamOS Stable/Beta testing if you use a custom or remote binary, for more info follow the URL in the comment above the testing section. -->
- [X] Tested on SteamOS Stable/Beta Update Channel.
