### PR TITLE
Update ControllerTools to v1.2.0

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -86,7 +86,7 @@
 	url = https://github.com/WerWolv/SDH-FreeGames
 [submodule "plugins/ControllerTools"]
 	path = plugins/ControllerTools
-	url = https://github.com/alphamercury/ControllerTools
+	url = https://github.com/jfernandez/ControllerTools
 [submodule "plugins/tailscale-control"]
 	path = plugins/tailscale-control
 	url = https://github.com/saumya-banthia/tailscale-control


### PR DESCRIPTION
# ControllerTools

Update ControllerTools to v1.2.0 and change the submodule to point to the new repository. The alphamercury repository is no longer maintained. You can verify this by going to the old url [1] and verifying that it redirects to the new url [2].

This new version pulls in the latest dependencies and makes the plugin use the global DFL to address an error [3] in the UI after the Steam Deck client update.

[1] https://github.com/alphamercury/ControllerTools
[2] https://github.com/jfernandez/ControllerTools
[3] https://github.com/jfernandez/ControllerTools/issues/43

## Checklist:

### Developer Checklist

- [X] I am the original author or an authorized maintainer of this plugin.
- [X] I have abided by the licenses of the libraries I am utilizing, including attaching license notices where appropriate.

### Plugin Checklist

- [X] I have verified that my plugin works properly on the Stable and Beta update channels of SteamOS.
- [X] I have verified my plugin is unique or alternatively provides more/alternative functionality to a similar plugin already on the store.

### Plugin Backend Checklist

- **Yes**: I am using a custom backend other than Python.
- **No**: I am using a tool or software from a 3rd party FOSS project that does not have it's dependencies [statically linked](https://en.wikipedia.org/wiki/Static_library).
- **Yes**: I am using a custom binary that has all of it's dependencies statically linked.

## Testing

Several users tested this new build in this Issue and verified it works: https://github.com/jfernandez/ControllerTools/issues/43

- [X] Tested on SteamOS Stable/Beta Update Channel.
- [X] Tested on SteamOS Preview Update Channel.
