### PR TITLE
steamdeck-input-disabler

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -225,3 +225,6 @@
 [submodule "plugins/SDH-PauseGames"]
 	path = plugins/SDH-PauseGames
 	url = https://github.com/wynn1212/SDH-PauseGames.git
+[submodule "plugins/docked-steamdeck-input-disabler"]
+	path = plugins/docked-steamdeck-input-disabler
+	url = https://gitlab.burritospray.com/BurritoSpray/docked-steamdeck-input-disabler.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -222,9 +222,9 @@
 [submodule "plugins/SDH-PauseGames"]
 	path = plugins/SDH-PauseGames
 	url = https://github.com/wynn1212/SDH-PauseGames.git
-[submodule "plugins/docked-steamdeck-input-disabler"]
-	path = plugins/docked-steamdeck-input-disabler
-	url = https://gitlab.burritospray.com/BurritoSpray/docked-steamdeck-input-disabler.git
 [submodule "plugins/SDH-Notebook"]
 	path = plugins/SDH-Notebook
 	url = https://github.com/wynn1212/SDH-Notebook.git
+[submodule "plugins/steamdeck-input-disabler"]
+	path = plugins/steamdeck-input-disabler
+	url = https://gitlab.burritospray.com/BurritoSpray/steamdeck-input-disabler.git


### PR DESCRIPTION
# Steamdeck Input Disabler

Adds an option to disable the steamdeck controls when a Bluetooth controller is connected. This fixes a bug where the steam deck is used instead of the Bluetooth game-pad when playing 4 player couch-coop games and emulators.

## Checklist:

### Developer Checklist

- [x] I am the original author or an authorized maintainer of this plugin.
- [x] I have abided by the licenses of the libraries I am utilizing, including attaching license notices where appropriate.

### Plugin Checklist

- [x] I have verified that my plugin works properly on the Stable and Beta update channels of SteamOS.
- [x] I have verified my plugin is unique or alternatively provides more/alternative functionality to a similar plugin already on the store.

### Plugin Backend Checklist

- **No**: I am using a custom backend other than Python.
- **No**: I am using a tool or software from a 3rd party FOSS project that does not have it's dependencies [statically linked](https://en.wikipedia.org/wiki/Static_library).
- **No**: I am using a custom binary that has all of it's dependencies statically linked.

## Testing

- [ ] Tested on SteamOS Stable/Beta Update Channel.
