### PR TITLE
Move NG projects to mirror

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -10,7 +10,7 @@
 	url = https://github.com/SDH-Stewardship/deckfaqs
 [submodule "plugins/PowerTools"]
 	path = plugins/PowerTools
-	url = https://git.ngni.us/NG-SD-Plugins/PowerTools
+	url = https://gitlab.com/NGnius/PowerTools
 [submodule "plugins/SDH-CssLoader"]
 	path = plugins/SDH-CssLoader
 	url = https://github.com/DeckThemes/SDH-CssLoader
@@ -34,7 +34,7 @@
 	url = https://github.com/Outpox/Bluetooth.git
 [submodule "plugins/Fantastic"]
 	path = plugins/Fantastic
-	url = https://git.ngni.us/NG-SD-Plugins/Fantastic
+	url = https://gitlab.com/NGnius/Fantastic
 [submodule "plugins/memory-deck"]
 	path = plugins/memory-deck
 	url = https://github.com/CameronRedmore/memory-deck.git


### PR DESCRIPTION
<!-- Make sure to include your plugin name below! -->

# PowerTools/Fantastic

This isn't a plugin update, just a repository URL change for both plugins.
Mitigates the issue with the CI failing to build unrelated plugins due to inaccessible submodules.

Leaving the rest of the PR template intact just in case, though it's probably not very relevant.

## Checklist:

### Developer Checklist

- [x] I am the original author or an authorized maintainer of this plugin.
- [x] I have abided by the licenses of the libraries I am utilizing, including attaching license notices where appropriate.

### Plugin Checklist

- [x] I have verified that my plugin works properly on the Stable and Beta update channels of SteamOS.
- [x] I have verified my plugin is unique or alternatively provides more/alternative functionality to a similar plugin already on the store.

<!-- The following section needs to be modified as yes/no answers by the plugin developer. -->

<!-- Ex: "**Yes/No**: ..." becomes "**Yes**: ..." -->

### Plugin Backend Checklist

- **Yes**: I am using a custom backend other than Python.
- **Yes**: I am using a tool or software from a 3rd party FOSS project that does not have it's dependencies [statically linked](https://en.wikipedia.org/wiki/Static_library).
- **No**: I am using a custom binary that has all of it's dependencies statically linked.

<!-- The following section is should be modified to fit the conditions for plugin testing found here: https://wiki.deckbrew.xyz/en/plugin-dev/review-and-testing -->

## Testing

- [ ] Tested on SteamOS Stable/Beta Update Channel.

- [ ] Tested on SteamOS Preview Update Channel.
