### PR TITLE
Moved steamdeck-input-disabler source to GitHub

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -225,3 +225,6 @@
 [submodule "plugins/SDH-PauseGames"]
 	path = plugins/SDH-PauseGames
 	url = https://github.com/wynn1212/SDH-PauseGames.git
+[submodule "plugins/docked-steamdeck-input-disabler"]
+	path = plugins/docked-steamdeck-input-disabler
+	url = https://gitlab.burritospray.com/BurritoSpray/docked-steamdeck-input-disabler.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -222,9 +222,9 @@
 [submodule "plugins/SDH-PauseGames"]
 	path = plugins/SDH-PauseGames
 	url = https://github.com/wynn1212/SDH-PauseGames.git
-[submodule "plugins/docked-steamdeck-input-disabler"]
-	path = plugins/docked-steamdeck-input-disabler
-	url = https://gitlab.burritospray.com/BurritoSpray/docked-steamdeck-input-disabler.git
 [submodule "plugins/SDH-Notebook"]
 	path = plugins/SDH-Notebook
 	url = https://github.com/wynn1212/SDH-Notebook.git
+[submodule "plugins/steamdeck-input-disabler"]
+	path = plugins/steamdeck-input-disabler
+	url = https://gitlab.burritospray.com/BurritoSpray/steamdeck-input-disabler.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -207,9 +207,6 @@
 [submodule "plugins/SDH-Notebook"]
 	path = plugins/SDH-Notebook
 	url = https://github.com/wynn1212/SDH-Notebook.git
-[submodule "plugins/steamdeck-input-disabler"]
-	path = plugins/steamdeck-input-disabler
-	url = https://gitlab.burritospray.com/BurritoSpray/steamdeck-input-disabler.git
 [submodule "plugins/Decky-Undervolt"]
 	path = plugins/Decky-Undervolt
 	url = https://github.com/totallynotbakadestroyer/Decky-Undervolt
@@ -222,3 +219,6 @@
 [submodule "plugins/decky-spy"]
 	path = plugins/decky-spy
 	url = https://github.com/Seraphli/decky-spy.git
+[submodule "plugins/steamdeck-input-disabler"]
+	path = plugins/steamdeck-input-disabler
+	url = https://github.com/BurritoSpray/steamdeck-input-disabler.git


### PR DESCRIPTION
<!-- Make sure to include your plugin name below! -->

# Steamdeck Input Disabler

Disable the steamdeck built-in gamepad

No changes to the code, only moved the source to GitHub instead of my self-hosted gitlab server, to prevent issues with my server being down and it will be easier if someone wants to contribute to the plugin.

## Checklist:

### Developer Checklist

- [x] I am the original author or an authorized maintainer of this plugin.
- [x] I have abided by the licenses of the libraries I am utilizing, including attaching license notices where appropriate.

### Plugin Checklist

- [x] I have verified that my plugin works properly on the Stable and Beta update channels of SteamOS.
- [x] I have verified my plugin is unique or alternatively provides more/alternative functionality to a similar plugin already on the store.

<!-- The following section needs to be modified as yes/no answers by the plugin developer. -->

<!-- Ex: "**Yes/No**: ..." becomes "**Yes**: ..." -->

### Plugin Backend Checklist

- **No**: I am using a custom backend other than Python.
- **No**: I am using a tool or software from a 3rd party FOSS project that does not have it's dependencies [statically linked](https://en.wikipedia.org/wiki/Static_library).
- **No**: I am using a custom binary that has all of it's dependencies statically linked.

<!-- The following section is should be modified to fit the conditions for plugin testing found here: https://wiki.deckbrew.xyz/en/plugin-dev/review-and-testing -->

## Testing

- [x] Tested on SteamOS Stable/Beta Update Channel.

- [x] Tested on SteamOS Preview Update Channel.
