### PR TITLE
Feat: Add git to builder image

### DIFF
--- a/builder/Dockerfile
+++ b/builder/Dockerfile
@@ -1,6 +1,6 @@
 FROM node:20-alpine
 
-RUN apk add --no-cache rsync
+RUN apk add --no-cache rsync git
 
 RUN npm i --location=global pnpm@9
 


### PR DESCRIPTION
it would be really quite nice to have git within the builder image. As long as the plugin.json is at the repo root the .git folder will be included and any build logic using git (such as embedding current git head) will work.

Relevant test run failing because git is missing.
https://github.com/CEbbinghaus/MicroSDeck/actions/runs/12411005427/job/34647794190