### PR TITLE
Add SDH-PlayTime

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -143,7 +143,7 @@
 	url = https://github.com/Alex4386/decky-terminal
 [submodule "plugins/SDH-PlayTime"]
 	path = plugins/SDH-PlayTime
-	url = https://github.com/ma3a/SDH-PlayTime.git
+	url = git@github.com:0u73r-h34v3n/SDH-PlayTime.git
 [submodule "plugins/Shotty"]
 	path = plugins/Shotty
 	url = https://github.com/safijari/Shotty


### PR DESCRIPTION
<!-- Make sure to include your plugin name below! -->

# SDH-PlayTime

This is a fork of original plugin [SDH-PlayTime](https://github.com/ma3a/SDH-PlayTime) which is archived right now.

In this update was:
- Improved code formatting (back-end & front-end)
- Fixed a case when EA Games play time session was not detected right.
- Implemented support of multiple sessions
  ![image](https://github.com/user-attachments/assets/2c775079-83db-4c4d-b8bc-2757e6d2b7fe)


## Checklist:

### Developer Checklist

- [ ] I am the original author or an authorized maintainer of this plugin.
- [ ] I have abided by the licenses of the libraries I am utilizing, including attaching license notices where appropriate.

### Plugin Checklist

- [x] I have verified that my plugin works properly on the Stable and Beta update channels of SteamOS.
- [ ] I have verified my plugin is unique or alternatively provides more/alternative functionality to a similar plugin already on the store.

<!-- The following section needs to be modified as yes/no answers by the plugin developer. -->

<!-- Ex: "**Yes/No**: ..." becomes "**Yes**: ..." -->

### Plugin Backend Checklist

- **No**: I am using a custom backend other than Python.
- **No**: I am using a tool or software from a 3rd party FOSS project that does not have it's dependencies [statically linked](https://en.wikipedia.org/wiki/Static_library).
- **No**: I am using a custom binary that has all of it's dependencies statically linked.

<!-- The following section is should be modified to fit the conditions for plugin testing found here: https://wiki.deckbrew.xyz/en/plugin-dev/review-and-testing -->

## Testing

- [ ] Tested on SteamOS Stable/Beta Update Channel.

- [ ] Tested on SteamOS Preview Update Channel.
