### PR TITLE
feat: add PlayCount Plugin

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -222,3 +222,6 @@
 [submodule "plugins/steamdeck-input-disabler"]
 	path = plugins/steamdeck-input-disabler
 	url = https://github.com/BurritoSpray/steamdeck-input-disabler.git
+[submodule "plugins/playcount-decky"]
+	path = plugins/playcount-decky
+	url = https://github.com/itsOwen/playcount-decky.git


### PR DESCRIPTION
### Plugin Description
PlayCount is a Steam Deck plugin that shows real-time player counts for Steam games directly in the UI. It helps users see how active a game's community is before launching.

### Features
- Clean and minimal interface
- Display Live Player Count in Steam Store.
- Display Live Player Count in Steam Library Games

### Developer Checklist
- [x] I am the original author or an authorized maintainer of this plugin.
- [x] I have abided by the licenses of the libraries I am utilizing, including attaching license notices where appropriate.

### Plugin Checklist
- [x] I have verified that my plugin works properly on the Stable and Beta update channels of SteamOS.
- [x] I have verified my plugin is unique or alternatively provides more/alternative functionality to a similar plugin already on the store.

### Plugin Backend Checklist
- Using custom backend other than Python: ✅ No
- Using 3rd party FOSS project tools without static linking: ✅ No
- Using custom binary with static linking: ✅ No

### Testing
- [ ] Tested on SteamOS Stable Update Channel.
- or
- [x] Tested on SteamOS Beta Update Channel.

- ✅ No special dependencies required
- ✅ No known conflicts with other plugins

### Additional Notes
- ✅ Plugin uses Steam's public API for player counts
- ✅ Lightweight implementation with minimal system impact
- ✅ All code is open source and well-documented