### PR TITLE
feat: add 'Crosshair' plugin to DB

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,4 +1,4 @@
-<!-- Make sure to include your plugin name below! -->
+<!-- Make sure to include your plugin name below and remove the reference to the testing page after visting the link! -->
 
 # Plugin Name
 
@@ -7,6 +7,14 @@ Please include a summary of what the plugin does.
 If this is an update, please include a summary of what changes you made.
 
 [If you have not already, please read the review and testing page on the [wiki](https://wiki.deckbrew.xyz/plugin-dev/review-and-testing). Remove this line before submitting your plugin.]
+
+## Plugin Repo
+
+<!-- Please submit both of your testing reports for the two plugins with you link to your comments on the respective PRs before filing your PR. -->
+[Please note that if no plugins/plugin updates are ready for testing at this time then you may state as much in this section but you will be asked to test any new plugins as soon as they are submitted.]
+- [ ] I agree to and have already tested at least two plugins that are newly submitted or having a pending update to help ensure the health of the plugin testing process for all contributors.
+- [ ] Plugin A: [Plugin Name (and version if being updated)]([https://github.com/](https://github.com/SteamDeckHomebrew/decky-plugin-database/pull/XYZ))
+- [ ] Plugin B: [Plugin Name (and version if being updated)]([https://github.com/](https://github.com/SteamDeckHomebrew/decky-plugin-database/pull/XYZ))
 
 ## Checklist:
 

--- a/.gitmodules
+++ b/.gitmodules
@@ -43,7 +43,7 @@
 	url = https://github.com/Tormak9970/bash-shortcuts.git
 [submodule "plugins/hltb-for-deck"]
 	path = plugins/hltb-for-deck
-	url = https://github.com/safijari/hltb-for-deck
+	url = https://github.com/morwy/hltb-for-deck
 [submodule "plugins/decky-autosuspend"]
 	path = plugins/decky-autosuspend
 	url = https://github.com/jurassicplayer/decky-autosuspend.git
@@ -222,6 +222,12 @@
 [submodule "plugins/steamdeck-input-disabler"]
 	path = plugins/steamdeck-input-disabler
 	url = https://github.com/BurritoSpray/steamdeck-input-disabler.git
+[submodule "plugins/decky-pip"]
+	path = plugins/decky-pip
+	url = https://github.com/rossimo/decky-pip
+[submodule "plugins/playcount-decky"]
+	path = plugins/playcount-decky
+	url = https://github.com/itsOwen/playcount-decky.git
 [submodule "plugins/Crosshair"]
 	path = plugins/Crosshair
 	url = https://github.com/xXJSONDeruloXx/crosshair-plugin.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -222,6 +222,3 @@
 [submodule "plugins/steamdeck-input-disabler"]
 	path = plugins/steamdeck-input-disabler
 	url = https://github.com/BurritoSpray/steamdeck-input-disabler.git
-[submodule "plugins/Crosshair"]
-	path = plugins/Crosshair
-	url = https://github.com/xXJSONDeruloXx/crosshair-plugin.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -222,3 +222,6 @@
 [submodule "plugins/steamdeck-input-disabler"]
 	path = plugins/steamdeck-input-disabler
 	url = https://github.com/BurritoSpray/steamdeck-input-disabler.git
+[submodule "plugins/Crosshair"]
+	path = plugins/Crosshair
+	url = https://github.com/xXJSONDeruloXx/crosshair-plugin.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -143,7 +143,7 @@
 	url = https://github.com/Alex4386/decky-terminal
 [submodule "plugins/SDH-PlayTime"]
 	path = plugins/SDH-PlayTime
-	url = https://github.com/ma3a/SDH-PlayTime.git
+	url = git@github.com:0u73r-h34v3n/SDH-PlayTime.git
 [submodule "plugins/Shotty"]
 	path = plugins/Shotty
 	url = https://github.com/safijari/Shotty


### PR DESCRIPTION
# Crosshair Plugin

This plugin overlays a customizable crosshair on the screen for use in games on the Steam Deck. It provides predefined crosshairs for 800p (Steam Deck) and 1080p (external displays, other handhelds) and allows users to adjust the crosshair position dynamically via the plugin UI.

## Checklist:

### Developer Checklist

- [x] I am the original author or an authorized maintainer of this plugin.
- [x] I have abided by the licenses of the libraries I am utilizing, including attaching license notices where appropriate.

### Plugin Checklist

- [x] I have verified that my plugin works properly on the Stable and Beta update channels of SteamOS.
- [x] I have verified my plugin is unique or alternatively provides more/alternative functionality to a similar plugin already on the store.

### Plugin Backend Checklist

- **No**: I am using a custom backend other than Python.
- **No**: I am using a tool or software from a 3rd party FOSS project that does not have it's dependencies [statically linked](https://en.wikipedia.org/wiki/Static_library).
- **No**: I am using a custom binary that has all of it's dependencies statically linked.


## Testing

- [x] Tested on SteamOS Stable/Beta Update Channel.

- [ ] Tested on SteamOS Preview Update Channel.
