### PR TITLE
added: simple-timer @ 1.0.0

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -231,3 +231,6 @@
 [submodule "plugins/Crosshair"]
 	path = plugins/Crosshair
 	url = https://github.com/xXJSONDeruloXx/crosshair-plugin.git
+[submodule "plugins/simple-timer"]
+	path = plugins/simple-timer
+	url = https://github.com/decktools-xyz/simple-timer.git


### PR DESCRIPTION
# simple-timer

A minimal plugin designed for simplicity and ease of use.

- Recent Timers for quick access to common situations
- Subtle mode to be alerted in a less invasive fashion
- An alarm will sound and give you the option to suspend immediately or ignore

## Plugin Repo

- [x] I agree to and have already tested at least two plugins that are newly submitted or having a pending update to help ensure the health of the plugin testing process for all contributors.
- [x] [deck-roulette (1.1.6)](https://github.com/SteamDeckHomebrew/decky-plugin-database/pull/717)
- [x] [decky-game-settings](https://github.com/SteamDeckHomebrew/decky-plugin-database/pull/747)

## Checklist:

### Developer Checklist

- [x] I am the original author or an authorized maintainer of this plugin.
- [x] I have abided by the licenses of the libraries I am utilizing, including attaching license notices where appropriate.

### Plugin Checklist

- [x] I have verified that my plugin works properly on the Stable and Beta update channels of SteamOS.
- [x] I have verified my plugin is unique or alternatively provides more/alternative functionality to a similar plugin already on the store.

### Plugin Backend Checklist

- **No**: I am using a custom backend other than Python.
- **No**: I am using a tool or software from a 3rd party FOSS project that does not have it's dependencies [statically linked](https://en.wikipedia.org/wiki/Static_library).
- **No**: I am using a custom binary that has all of it's dependencies statically linked.

## Testing

- [x] Tested on SteamOS Stable/Beta Update Channel.