### PR TITLE
Add LetMeReShade Plugin

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -222,3 +222,6 @@
 [submodule "plugins/steamdeck-input-disabler"]
 	path = plugins/steamdeck-input-disabler
 	url = https://github.com/BurritoSpray/steamdeck-input-disabler.git
+[submodule "plugins/playcount-decky"]
+	path = plugins/playcount-decky
+	url = https://github.com/itsOwen/playcount-decky.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -238,3 +238,6 @@
 	path = plugins/decky-dot-dns
 	url = https://github.com/ohaiibuzzle/decky-dot-dns.git
 	branch = tags/v0.0.3
+[submodule "plugins/LetMeReShade"]
+	path = plugins/LetMeReShade
+	url = https://github.com/itsOwen/LetMeReShade.git


### PR DESCRIPTION
# LetMeReShade Plugin
A seamless ReShade integration for Steam Deck that enables advanced shader customization and graphics enhancement. This plugin provides easy ReShade installation, game-specific shader application, and preset management.

## Task Checklist
### Developer
- [x] I am the original author or an authorized maintainer of this plugin.
- [x] I have abided by the licenses of the libraries I am utilizing, including attaching license notices where appropriate.

### Plugin
- [x] I have verified that my plugin works properly on the Stable and Beta update channels of SteamOS.
- [x] I have verified my plugin is unique or provides more/alternative functionality to a plugin already on the store.

### Backend
- **No**: I am using a custom backend other than Python.
- **No**: I am using a tool or software from a 3rd party FOSS project that does not have it's dependencies statically linked.
- **No**: I am using a custom binary that has all of it's dependencies statically linked.

### Community
- [ ] I have tested and left feedback on two other pull requests for new or updating plugins.
- [ ] I have commented links to my testing report in this PR.

## Testing
- [ ] Tested on SteamOS Stable or Beta update channel.