### PR TITLE
feat: add decky-lookup

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -245,3 +245,6 @@
 	path = plugins/decky-dot-dns
 	url = https://github.com/ohaiibuzzle/decky-dot-dns.git
 	branch = tags/v0.0.3
+[submodule "plugins/Decky-Lookup"]
+	path = plugins/Decky-Lookup
+	url = https://github.com/xXJSONDeruloXx/Decky-Lookup.git


### PR DESCRIPTION
# Decky Lookup

Decky Lookup is a convenient Quick Access menu plugin that provides one-click access to popular gaming resources and information sites for your currently running Steam game. It automatically uses the current game's name/ID to search across multiple useful websites.

### Supported Sites:
- Google Search - Quick web search for current game
- PC Gaming Wiki - Technical information, fixes and tweaks
- ProtonDB - Linux/Steam Deck compatibility reports 
- HowLongToBeat - Game completion time estimates
- Steam Deck HQ - Steam Deck optimization guides
- GameFAQs - Walkthroughs and guides

The plugin falls back to the homepage of each site if no game is running.


## Task Checklist

### Developer
- [x] I am the original author or an authorized maintainer of this plugin.
- [x] I have abided by the licenses of the libraries I am utilizing, including attaching license notices where appropriate.

### Plugin
- [x] I have verified that my plugin works properly on the Stable and Beta update channels of SteamOS.
- [x] I have verified my plugin is unique or provides more/alternative functionality to a plugin already on the store.

### Backend
- **No**: I am using a custom backend other than Python.
- **No**: I am using a tool or software from a 3rd party FOSS project that does not have it's dependencies statically linked.
- **No**: I am using a custom binary that has all of it's dependencies statically linked.

### Community
- [ ] I have tested and left feedback on two other pull requests for new or updating plugins.
- [ ] I have commented links to my testing report in this PR.

## Testing
- [x] Tested by a third party on SteamOS Stable or Beta update channel.