### PR TITLE
plugin: add wifi-locker plugin

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -272,3 +272,6 @@
 [submodule "plugins/SDH-GameSync"]
 	path = plugins/SDH-GameSync
 	url = https://github.com/AkazaRenn/SDH-GameSync.git
+[submodule "plugins/decky-wifi-locker"]
+	path = plugins/decky-wifi-locker
+	url = git@github.com:felipejfc/decky-wifi-locker.git


### PR DESCRIPTION
# WiFi Locker

WiFi Locker is a utility plugin that allows Steam Deck users to lock their WiFi connection to the current access point by binding to its specific BSSID. This prevents the WiFi adapter from performing background scanning, which can cause latency spikes and connection instability during gaming sessions.

**Key features:**
- Lock WiFi to current access point with a single click
- Unlock when needed to restore normal WiFi operation
- Clear status display showing lock state and connected network
- Informative UI explaining benefits and optimal usage scenarios

**Benefits for gamers:**
- Reduces random latency spikes during online gaming / streaming applications
- Improves connection stability for a more consistent experience
- May help conserve battery by reducing unnecessary scanning

The plugin is designed with a clean, intuitive interface that fits seamlessly with the Steam Deck UI. It's particularly useful for users who experience network stuttering or lag spikes while streaming on WiFi.

![WiFi Locker Screenshot](https://raw.githubusercontent.com/felipejfc/decky-wifi-locker/main/assets/screenshot.jpg)

## Task Checklist

### Developer

- [x] I am the original author or an authorized maintainer of this plugin.
- [x] I have abided by the licenses of the libraries I am utilizing, including attaching license notices where appropriate.

### Plugin

- [x] I have verified that my plugin works properly on the Stable and Beta update channels of SteamOS.
- [x] I have verified my plugin is unique or provides more/alternative functionality to a plugin already on the store.

### Backend

- **No**: I am using a custom backend other than Python.
- **No**: I am not using a tool or software from a 3rd party FOSS project that does not have its dependencies statically linked.
- **No**: I am not using a custom binary that has all of its dependencies statically linked.

### Community

- [ ] I have tested and left feedback on two other [pull requests][pulls] for new or updating plugins.
- [ ] I have commented links to my testing report in this PR.

## Testing

- [ ] Tested by a third party on SteamOS Stable or Beta update channel.

[pulls]: https://github.com/steamdeckHomebrew/decky-plugin-database/pulls?q=is%3Apr+is%3Aopen+sort%3Acreated-desc+-status%3Afailure+-draft%3Atrue+-author%3A%40me