### PR TITLE
chore: update readme instructions, link to test guide and tracker

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,9 +13,22 @@ To submit a plugin to Decky's plugin store, open a pull request adding your plug
 Don't forget to bump your version number in package.json.
 If you are not sure how to make a submodule, please reference the [git docs](https://git-scm.com/book/en/v2/Git-Tools-Submodules) on submodules.
 
-Once you have your submodule added, in order to update it,  
-change directories to ``plugins/your-plugin`` and run ``git submodule update --init``.  
-This should update your plugin to the latest version.
+Once you have your submodule added, in order to update it to a newer version:
+
+1. `git checkout main` (ensure you are in sync with upstream from your fork and pull)
+2. `git checkout -b update/your-plugin` (or whatever you like to call it)
+3. `cd plugins/your-plugin`
+4. `git pull`
+5. `cd ../..`
+6. `git add plugins/your-plugin`
+7. `git commit -m "your commit message"`
+8. `git push`
+
+## Testing Other's Plugins
+
+While not required, testing other developers' plugins can help the community and may prioritize your own pull request. If you choose to participate in community testing, you can follow the [testing guide](https://wiki.deckbrew.xyz/user-guide/testing) to learn how to test other plugins and provide valuable feedback.
+
+You can easily track PRs that are ready for review in this view: [SDH Tracker](https://github.com/orgs/SteamDeckHomebrew/projects/9/views/11)
 
 Please make sure your plugin is compliant with the pull-request template's steps.
 Plugins found to be out of compliance will not be accepted.


### PR DESCRIPTION
## Description

<!--
    Describe your changes in detail below.
-->

Minor changes to ReadMe:

- link to testing guidelines wiki which has the plugin testing template, I struggle to find it every time lol
- link to the SDH tracker which highlights plugins ready to test, should make it more convenient to get engagement (instead of hunting down the pin on the discord)
- updated the step by step instructions for updating an existing plugin (previous instructions init all submodules IME, whats listed is my process, but let me know if any differing opinions on that aspect)


Mainly just QOL tweaks to centralize some Discord captured knowledge and get links in a convenient place!

## Checklist

<!--
    Please change [ ] to [x] to check the box below to confirm your changes.
-->

- [X] This is not a plugin-related change, only a change to the repository or database system.
