### PR TITLE
Add Network Sentinel plugin

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -286,3 +286,6 @@
 	path = plugins/MuraDeck
 	url = https://github.com/Moonveil-Kanata/MuraDeck.git
 	branch = main
+[submodule "plugins/network-sentinel"]
+	path = plugins/network-sentinel
+	url = https://github.com/KrishGaur1354/network-sentinel.git


### PR DESCRIPTION
# Network Sentinel

Monitor network quality and track connection performance with live ping display, latency graphs, and network history tracking for Steam Deck.

## Checklist:

### Developer Checklist

* [x] I am the original author or an authorized maintainer of this plugin.
* [x] I have abided by the licenses of the libraries I am utilizing, including attaching license notices where appropriate.

### Plugin Checklist

* [ ] I have verified that my plugin works properly on the Stable and Beta update channels of SteamOS.
* [x] I have verified my plugin is unique or alternatively provides more/alternative functionality to a similar plugin already on the store.

### Plugin Backend Checklist

* **No**: I am using a custom backend other than Python.
* **No**: I am using a tool or software from a 3rd party FOSS project that does not have it's dependencies [statically linked](https://en.wikipedia.org/wiki/Static_library).
* **No**: I am using a custom binary that has all of it's dependencies statically linked.

## Testing

* [x] Tested on SteamOS Stable Update Channel.
* [ ] Tested on SteamOS Beta Update Channel.
