### PR TITLE
Add deck-progress-tracker to Plugin Store

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -350,3 +350,6 @@
 [submodule "plugins/decky-download-all"]
 	path = plugins/decky-download-all
 	url = https://github.com/bentemple/decky-download-all.git
+[submodule "plugins/deck-progress-tracker"]
+	path = plugins/deck-progress-tracker
+	url = https://github.com/maroun2/deck-progress-tracker.git


### PR DESCRIPTION
# Add deck-progress-tracker to Plugin Store

Deck Progress Tracker is a Decky Loader plugin that tracks your gaming progress across your Steam library. It automatically categorizes games by completion status (Not Started, In Progress, Completed) using playtime data and HowLongToBeat integration. It provides a dashboard with progress stats and filtering accessible from the Quick Access Menu.

## Task Checklist

### Developer

- [x] I am the original author or an authorized maintainer of this plugin.
- [x] I have abided by the licenses of the libraries I am utilizing, including attaching license notices where appropriate.

### Plugin

- [x] I have verified that my plugin works properly on the Stable update channel of SteamOS. Beta testing was not possible — Decky Loader does not currently load on SteamOS 3.7.20 Beta ([decky-loader#837](https://github.com/SteamDeckHomebrew/decky-loader/issues/837)).
- [x] I have verified my plugin is unique or provides more/alternative functionality to a plugin already on the store.

### Backend

- **No**: I am using a custom backend other than Python.
- **No**: I am using a tool or software from a 3rd party FOSS project that does not have it's dependencies statically linked.
- **No**: I am using a custom binary that has all of it's dependencies statically linked.

### Community

- [x] I have tested and left feedback on two other [pull requests][pulls] for new or updating plugins.

## Testing

- [ ] Tested by a third party on SteamOS Stable or Beta update channel.

[pulls]: https://github.com/steamdeckHomebrew/decky-plugin-database/pulls?q=is%3Apr+is%3Aopen+sort%3Acreated-desc+-status%3Afailure+-draft%3Atrue+-author%3A%40me