### PR TITLE
Add Download All to Plugin Store

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -347,3 +347,6 @@
 [submodule "plugins/decky-multi-user"]
 	path = plugins/decky-multi-user
 	url = https://github.com/nikitaclicks/decky-multi-user
+[submodule "plugins/decky-download-all"]
+	path = plugins/decky-download-all
+	url = https://github.com/bentemple/decky-download-all.git


### PR DESCRIPTION
# Add Download All to Plugin Store

This plugin adds a simple UI to allow the user to batch start their scheduled downloads. By default it queues all scheduled downloads to run immediately, ordered by size smallest to largest. It can also be configured to queue all (scheduled and unscheduled) or scheduled but only up to a maximum size limit.

<img width="1280" height="800" alt="image" src="https://github.com/user-attachments/assets/3b6cb34a-9bb1-4b0b-99e3-1a3e0f84d38c" />

## Task Checklist

### Developer

- [x] I am the original author or an authorized maintainer of this plugin.
- [x] I have abided by the licenses of the libraries I am utilizing, including attaching license notices where appropriate.

### Plugin

- [x] I have verified that my plugin works properly on the Stable and Beta update channels of SteamOS.
- [x] I have verified my plugin is unique or provides more/alternative functionality to a plugin already on the store.

### Backend

- **No**: I am using a custom backend other than Python.
- **No**: I am using a tool or software from a 3rd party FOSS project that does not have it's dependencies [statically linked](https://en.wikipedia.org/wiki/Static_library).
- **No**: I am using a custom binary that has all of it's dependencies statically linked.

### Community

- [ ] I have tested and left feedback on two other [pull requests][pulls] for new or updating plugins.
- [ ] I have commented links to my testing report in this PR.

## Testing

- [ ] Tested by a third party on SteamOS Stable or Beta update channel.

[pulls]: https://github.com/steamdeckHomebrew/decky-plugin-database/pulls?q=is%3Apr+is%3Aopen+sort%3Acreated-desc+-status%3Afailure+-draft%3Atrue+-author%3A%40me
