### PR TITLE
Add MuteOnSleep to Plugin Store

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -350,3 +350,6 @@
 [submodule "plugins/decky-download-all"]
 	path = plugins/decky-download-all
 	url = https://github.com/bentemple/decky-download-all.git
+[submodule "plugins/MuteOnWake"]
+	path = plugins/MuteOnWake
+	url = https://github.com/genc-v/mute-on-sleep

--- a/.gitmodules
+++ b/.gitmodules
@@ -350,6 +350,6 @@
 [submodule "plugins/decky-download-all"]
 	path = plugins/decky-download-all
 	url = https://github.com/bentemple/decky-download-all.git
-[submodule "plugins/MuteOnWake"]
-	path = plugins/MuteOnWake
+[submodule "plugins/MuteOnSleep"]
+	path = plugins/MuteOnSleep
 	url = https://github.com/genc-v/mute-on-sleep


### PR DESCRIPTION
Automatically mutes your Steam Deck's audio right before it goes to sleep, so you don't get blasted with sound when you wake it up in public. Uses a toggle in the Quick Access Menu to enable/disable. Hooks into the Steam client's `SuspendResumeStore` via MobX to detect suspension, then calls `pactl` to mute and set volume to 0%.

## Task Checklist

### Developer

- [x] I am the original author or an authorized maintainer of this plugin.
- [x] I have abided by the licenses of the libraries I am utilizing, including attaching license notices where appropriate.

### Plugin

- [x] I have verified that my plugin works properly on the Stable and Beta update channels of SteamOS.
- [x] I have verified my plugin is unique or provides more/alternative functionality to a plugin already on the store.

### Backend

- **No**: I am using a custom backend other than Python.
- **No**: I am using a tool or software from a 3rd party FOSS project that does not have it's dependencies statically linked.
- **No**: I am using a custom binary that has all of it's dependencies statically linked.


[pulls]: https://github.com/steamdeckHomebrew/decky-plugin-database/pulls?q=is%3Apr+is%3Aopen+sort%3Acreated-desc+-status%3Afailure+-draft%3Atrue+-author%3A%40me