### PR TITLE
feat: Add decky-proton-launch plugin to Plugin Store

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -359,3 +359,6 @@
 [submodule "plugins/decky-nonsteam-badges"]
 	path = plugins/decky-nonsteam-badges
 	url = https://github.com/sebet/decky-nonsteam-badges
+[submodule "plugins/decky-proton-launch"]
+	path = plugins/decky-proton-launch
+	url = https://github.com/moi952/decky-proton-launch.git


### PR DESCRIPTION
# Add Decky Proton Launch to Plugin Store

Decky Proton Launch is a plugin that provides a simple and intuitive interface to manage Proton launch options directly from the Steam Deck UI. It allows users to enable commonly used Proton environment variables (FSR4, DLSS4, XeSS, DXVK Async, ESYNC/FSYNC, MangoHud) on a per-game basis. The plugin automatically detects the currently running game and applies settings upon the next launch. It supports 16 languages and displays update notifications with direct download links.

## Task Checklist

### Developer

- [x] I am the original author or an authorized maintainer of this plugin.
- [x] I have abided by the licenses of the libraries I am utilizing, including attaching license notices where appropriate.

### Plugin

- [x] I have verified that my plugin works properly on the Stable and Beta update channels of SteamOS.
- [x] I have verified my plugin is unique or provides more/alternative functionality to a plugin already on the store.

### Backend

- **No**: I am using a custom backend other than Python.
- **No**: I am using a tool or software from a 3rd party FOSS project that does not have its dependencies statically linked.
- **No**: I am using a custom binary that has all of its dependencies statically linked.

### Community

- [x] I have tested and left feedback on two other [pull requests][pulls] for new or updating plugins.
- [x] I have commented links to my testing report in this PR.

## Testing

- [x] Tested by a third party on SteamOS Stable or Beta update channel.

[pulls]: https://github.com/steamdeckHomebrew/decky-plugin-database/pulls?q=is%3Apr+is%3Aopen+sort%3Acreated-desc+-status%3Afailure+-draft%3Atrue+-author%3A%40me
