### PR TITLE
Add Prysm to Plugin Store

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -350,3 +350,6 @@
 [submodule "plugins/decky-download-all"]
 	path = plugins/decky-download-all
 	url = https://github.com/bentemple/decky-download-all.git
+[submodule "plugins/Prysm"]
+	path = plugins/Prysm
+	url = https://github.com/hostsrc/decky-prysm.git


### PR DESCRIPTION
# Add Prysm to Plugin Store

Prysm streams your Steam Deck screen to any browser on your local network. One-tap start from Game Mode with hardware-accelerated VAAPI H.264 encoding.

**Features:**
- Two streaming methods: MPEG-TS (~500ms latency) and WebRTC (~200ms latency via MediaMTX)
- Quality presets: 480p30, 720p30, 720p60, 1080p30, 1080p60
- Live stats in QAM (viewers, bytes sent, encoder status)
- Auto-restart on capture failure
- All native Decky UI components

**Repository:** https://github.com/hostsrc/decky-prysm
**License:** GPL-3.0

## Task Checklist

### Developer

- [x] I am the original author or an authorized maintainer of this plugin.
- [x] I have abided by the licenses of the libraries I am utilizing, including attaching license notices where appropriate.
- [ ] Generative AI was NOT used to write a majority of the code I am submitting.

### Plugin

- [x] I have verified that my plugin works properly on the Stable and Beta update channels of SteamOS.
- [x] I have verified my plugin is unique or provides more/alternative functionality to a plugin already on the store.

### Backend

- **No**: I am using a custom backend other than Python.
- **No**: I am using a tool or software from a 3rd party FOSS project that does not have it's dependencies [statically linked](https://en.wikipedia.org/wiki/Static_library).
- **Yes**: I am using a custom binary that has all of it's dependencies statically linked.

### Community

- [ ] I have tested and left feedback on two other [pull requests][pulls] for new or updating plugins.
- [ ] I have commented links to my testing report in this PR.

## Testing

- [ ] Tested by a third party on SteamOS Stable or Beta update channel.

[pulls]: https://github.com/steamdeckHomebrew/decky-plugin-database/pulls?q=is%3Apr+is%3Aopen+sort%3Acreated-desc+-status%3Afailure+-draft%3Atrue+-author%3A%40me