### PR TITLE
Add generative AI warnings, checkboxes

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/plugin_addition.md
+++ b/.github/PULL_REQUEST_TEMPLATE/plugin_addition.md
@@ -1,5 +1,6 @@
 <!--
     READ ALL COMMENTS IN THIS TEMPLATE BEFORE SUBMITTING YOUR PR!
+    NOT FOLLOWING THIS TEMPLATE MAY RESULT IN YOUR PR BEING DENIED FOR SUSPECTED AI USAGE!
 
     This template is for adding a new plugin to the store. If you are taking any other action, please start over by creating a new pull request and selecting the appropriate template.
 
@@ -32,6 +33,7 @@ REPLACE_WITH_SUMMARY
 
 - [ ] I am the original author or an authorized maintainer of this plugin.
 - [ ] I have abided by the licenses of the libraries I am utilizing, including attaching license notices where appropriate.
+- [ ] Generative AI was NOT used to write a majority of the code I am submitting.
 
 ### Plugin
 

--- a/.github/PULL_REQUEST_TEMPLATE/plugin_removal.md
+++ b/.github/PULL_REQUEST_TEMPLATE/plugin_removal.md
@@ -1,5 +1,6 @@
 <!--
     READ ALL COMMENTS IN THIS TEMPLATE BEFORE SUBMITTING YOUR PR!
+    NOT FOLLOWING THIS TEMPLATE MAY RESULT IN YOUR PR BEING DENIED FOR SUSPECTED AI USAGE!
 
     This template is for removing a plugin from the store. If you are taking any other action, please start over by creating a new pull request and selecting the appropriate template.
 

--- a/.github/PULL_REQUEST_TEMPLATE/plugin_transfer.md
+++ b/.github/PULL_REQUEST_TEMPLATE/plugin_transfer.md
@@ -1,5 +1,6 @@
 <!--
     READ ALL COMMENTS IN THIS TEMPLATE BEFORE SUBMITTING YOUR PR!
+    NOT FOLLOWING THIS TEMPLATE MAY RESULT IN YOUR PR BEING DENIED FOR SUSPECTED AI USAGE!
 
     This template is for updating an existing plugin on the store AND changing the repository it is linked to. If you are taking any other action, please start over by creating a new pull request and selecting the appropriate template.
 
@@ -43,6 +44,7 @@ REPLACE_WITH_CHANGE_REASONS
 - [ ] The original author or authorized maintainer of this plugin has either agreed to the transfer or has been unresponsive for an extended period as described above.
 - [ ] I am accept the responsibility of becoming the authorized maintainer of this plugin.
 - [ ] I have abided by the licenses of the libraries I am utilizing, including attaching license notices where appropriate.
+- [ ] Generative AI was NOT used to write a majority of the code I am submitting.
 
 ### Plugin
 

--- a/.github/PULL_REQUEST_TEMPLATE/plugin_update.md
+++ b/.github/PULL_REQUEST_TEMPLATE/plugin_update.md
@@ -1,5 +1,6 @@
 <!--
     READ ALL COMMENTS IN THIS TEMPLATE BEFORE SUBMITTING YOUR PR!
+    NOT FOLLOWING THIS TEMPLATE MAY RESULT IN YOUR PR BEING DENIED FOR SUSPECTED AI USAGE!
 
     This template is for updating an existing plugin on the store WITHOUT changing the repository it is linked to. If you are taking any other action, please start over by creating a new pull request and selecting the appropriate template.
 
@@ -32,6 +33,7 @@ REPLACE_WITH_SUMMARY
 
 - [ ] I am the original author or an authorized maintainer of this plugin.
 - [ ] I have abided by the licenses of the libraries I am utilizing, including attaching license notices where appropriate.
+- [ ] Generative AI was NOT used to write a majority of the code I am submitting.
 
 ### Plugin
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,5 +1,7 @@
 DO NOT USE THIS TEMPLATE. Select the Preview tab and click the appropriate link to access the correct sub-template.
 
+NOT FOLLOWING A TEMPLATE MAY RESULT IN YOUR PR BEING DENIED FOR SUSPECTED AI USAGE!
+
 - [Plugin addition](?expand=1&template=plugin_addition.md) - Plugins that are entirely new to the store.
 - [Plugin update](?expand=1&template=plugin_update.md) - Updating an existing plugin on the store WITHOUT changing the repository it is linked to.
 - [Plugin transfer](?expand=1&template=plugin_transfer.md) - Updating an existing plugin on the store AND changing the repository it is linked to.


### PR DESCRIPTION
## Description

<!--
    Describe your changes in detail below.
-->

Adds a warning and a mandatory checkbox to PR templates regarding the use of generative AI when developing plugins. Per our [plugin submission guide](https://wiki.deckbrew.xyz/en/plugin-dev/submitting-plugins) and [plugin safety](https://wiki.deckbrew.xyz/en/user-guide/plugin-safety) pages on our wiki, excessive use of generative AI in plugin development is considered unsafe and unwanted on the Decky plugin store.

## Checklist

<!--
    Please change [ ] to [x] to check the box below to confirm your changes.
-->

- [x] This is not a plugin-related change, only a change to the repository or database system.
