### PR TITLE
Add allmazz/decky-desktop-apps

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -358,4 +358,4 @@
 	url = https://github.com/sebet/decky-nonsteam-badges
 [submodule "plugins/decky-apps"]
 	path = plugins/decky-apps
-	url = https://github.com/allmazz/decky-apps
+	url = https://github.com/allmazz/decky-apps.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -350,3 +350,6 @@
 [submodule "plugins/decky-download-all"]
 	path = plugins/decky-download-all
 	url = https://github.com/bentemple/decky-download-all.git
+[submodule "plugins/decky-apps"]
+	path = plugins/decky-apps
+	url = https://github.com/allmazz/decky-apps.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -356,6 +356,6 @@
 [submodule "plugins/decky-nonsteam-badges"]
 	path = plugins/decky-nonsteam-badges
 	url = https://github.com/sebet/decky-nonsteam-badges
-[submodule "plugins/decky-apps"]
-	path = plugins/decky-apps
-	url = https://github.com/allmazz/decky-apps.git
+[submodule "plugins/decky-desktop-apps"]
+	path = plugins/decky-desktop-apps
+	url = https://github.com/allmazz/decky-desktop-apps.git


### PR DESCRIPTION
<!--
    READ ALL COMMENTS IN THIS TEMPLATE BEFORE SUBMITTING YOUR PR!
    NOT FOLLOWING THIS TEMPLATE MAY RESULT IN YOUR PR BEING DENIED FOR SUSPECTED AI USAGE!

    This template is for adding a new plugin to the store. If you are taking any other action, please start over by creating a new pull request and selecting the appropriate template.

    If you have not already, please read the review and testing page on the wiki.
    https://wiki.deckbrew.xyz/plugin-dev/review-and-testing

    Before submitting, make sure you have done the following:
    - Tested two other plugins and left feedback on their PRs as described below.
    - Replaced REPLACE_WITH_PLUGIN_NAME and REPLACE_WITH_SUMMARY with the appropriate information.
    - Filled out the Task Checklist, including the Yes/No questions.
    - Deleted the unnecessary testing checkbox.
-->

# Add Desktop Apps to Plugin Store

<!--
    Include a detailed summary of what the plugin does, attaching images or videos if necessary. If your plugin has similar functionality to another plugin on the store, explain how it differs and why your plugin should be allowed on the store.
-->

Run your desktop apps from game mode without switching to desktop.
[Read more](https://github.com/allmazz/decky-desktop-apps/blob/main/README.md).

There is similar plugin named Quick Launch, but it does not support one-shot runs without adding persistent shortcut and have less convenient interface(in my opinion). I tried to make Apps as simple as possible with must-have features.

## Task Checklist

<!--
    For checkboxes, change [ ] to [x] to check the box.
    For Yes/No questions, replace "Yes/No" with "Yes" or "No".
-->

### Developer

- [x] I am the original author or an authorized maintainer of this plugin.
- [x] I have abided by the licenses of the libraries I am utilizing, including attaching license notices where appropriate.
- [x] Generative AI was NOT used to write a majority of the code I am submitting.

### Plugin

- [x] I have verified that my plugin works properly on the Stable and Beta update channels of SteamOS.
- [x] I have verified my plugin is unique or provides more/alternative functionality to a plugin already on the store.

### Backend

- **No**: I am using a custom backend other than Python.
- **No**: I am using a tool or software from a 3rd party FOSS project that does not have it's dependencies [statically linked](https://en.wikipedia.org/wiki/Static_library).
- **No**: I am using a custom binary that has all of it's dependencies statically linked.

### Community

<!--
    Please submit both of your testing reports before creating your PR. You will need to link the comments you left in a comment on this PR.

    If no plugin additions or updates are ready for testing at this time, then you may ignore this checkbox. You may be asked to test new plugins as they are submitted.

    Your PR will be prioritized lower if you do not test other plugins, but this step is optional.
-->

- [ ] I have tested and left feedback on two other [pull requests][pulls] for new or updating plugins.
- [ ] I have commented links to my testing report in this PR.

## Testing

<!--
    DO NOT FORGET THIS STEP! Otherwise, testers may incorrectly test your plugin.

    If your plugin uses the provided Python backend and React frontend, your plugin must be tested on the Stable or Beta update channel of SteamOS. REMOVE the line with the Preview checkbox below.

    If your plugin uses a custom backend or pre-build binaries without statically linked dependency (ex. glibc), your plugin must be tested on the SteamOS Preview update channel. REMOVE the line with the Stable or Beta checkbox below.

    DO NOT CHECK THIS BOX YOURSELF UNLESS SOMEONE HAS COMMENTED A TESTING REPORT FOR YOUR PLUGIN! This will lead to delays in the review process.
-->

- [ ] Tested by a third party on SteamOS Stable or Beta update channel.

[pulls]: https://github.com/steamdeckHomebrew/decky-plugin-database/pulls?q=is%3Apr+is%3Aopen+sort%3Acreated-desc+-status%3Afailure+-draft%3Atrue+-author%3A%40me
