### PR TITLE
Add deck-stats plugin

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -350,3 +350,6 @@
 [submodule "plugins/decky-download-all"]
 	path = plugins/decky-download-all
 	url = https://github.com/bentemple/decky-download-all.git
+[submodule "plugins/deck-stats"]
+	path = plugins/deck-stats
+	url = https://github.com/iwsen/deck-stats.git


### PR DESCRIPTION
# Add Deck Stats to Plugin Store

Per-game playtime tracker for Steam Deck. Automatically detects running games, records sessions to SQLite, and displays stats through a built-in interface.

**Features:**
- Automatic session tracking via `/proc/*/environ` polling
- Docked vs handheld time split per session
- Activity heatmap (7×24 grid by day-of-week and hour-of-day)
- Play streaks and milestones (10/25/50/100/250/500/1000 hours)
- Daily/weekly/monthly goals per game or globally
- Session editor — modify, delete, or manually create sessions
- Export/import as JSON
- 10 languages: English, Russian, Chinese, Spanish, Portuguese-BR, German, French, Polish, Turkish, Japanese

## Task Checklist

### Developer

- [x] I am the original author or an authorized maintainer of this plugin.
- [x] I have abided by the licenses of the libraries I am utilizing, including attaching license notices where appropriate.
- [x] Generative AI was NOT used to write a majority of the code I am submitting.

### Plugin

- [x] I have verified that my plugin works properly on the Stable and Beta update channels of SteamOS.
- [x] I have verified my plugin is unique or provides more/alternative functionality to a plugin already on the store.

### Backend

- **No**: I am using a custom backend other than Python.
- **No**: I am using a tool or software from a 3rd party FOSS project that does not have it's dependencies statically linked.
- **No**: I am using a custom binary that has all of it's dependencies statically linked.

### Community

- [ ] I have tested and left feedback on two other [pull requests][pulls] for new or updating plugins.
- [ ] I have commented links to my testing report in this PR.

## Testing

- [ ] Tested by a third party on SteamOS Stable or Beta update channel.

[pulls]: https://github.com/steamdeckHomebrew/decky-plugin-database/pulls?q=is%3Apr+is%3Aopen+sort%3Acreated-desc+-status%3Afailure+-draft%3Atrue+-author%3A%40me