### PR TITLE
Add easy-ssh plugin

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -353,3 +353,6 @@
 [submodule "plugins/decky-download-all"]
 	path = plugins/decky-download-all
 	url = https://github.com/bentemple/decky-download-all.git
+[submodule "plugins/easy-ssh"]
+	path = plugins/easy-ssh
+	url = https://github.com/heynedim/easy-ssh.git


### PR DESCRIPTION
# Add Easy SSH to Plugin Store

Easy SSH is a Decky Loader plugin for the Steam Deck that allows users to quickly toggle the SSH service on and off directly from the Quick Access Menu, without needing to enter Desktop Mode. It natively utilizes standard SteamOS Polkit scripts for seamless toggling and provides an optional sudo password bypass for customized systems. It also displays the current local IP address and live backend logs for easy troubleshooting.

## Task Checklist

### Developer

- [x] I am the original author or an authorized maintainer of this plugin.
- [x] I have abided by the licenses of the libraries I am utilizing, including attaching license notices where appropriate.
- [x] Generative AI was NOT used to write a majority of the code I am submitting.

### Plugin

- [x] I have verified that my plugin works properly on the Stable and Beta update channels of SteamOS.
- [x] I have verified my plugin is unique or provides more/alternative functionality to a plugin already on the store.

### Backend

- **No**: I am using a custom backend other than Python.
- **No**: I am using a tool or software from a 3rd-party FOSS project that does not have its dependencies statically linked.
- **No**: I am using a custom binary that has all of its dependencies statically linked.

### Community

- [ ] I have tested and left feedback on two other [pull requests][pulls] for new or updated plugins.
- [ ] I have commented links to my testing report in this PR.

## Testing

- [ ] Tested by a third party on SteamOS Stable or Beta update channel.

[pulls]: https://github.com/steamdeckHomebrew/decky-plugin-database/pulls?q=is%3Apr+is%3Aopen+sort%3Acreated-desc+-status%3Afailure+-draft%3Atrue+-author%3A%40me
