### PR TITLE
Add/hercules codes

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -359,3 +359,6 @@
 [submodule "plugins/decky-nonsteam-badges"]
 	path = plugins/decky-nonsteam-badges
 	url = https://github.com/sebet/decky-nonsteam-badges
+[submodule "plugins/hercules-codes"]
+	path = plugins/hercules-codes
+	url = https://github.com/RNovachkov/hercules-codes


### PR DESCRIPTION
###  Very simple plugin for Disney's Hercules

**What it does**

  Displays 4-symbol level passwords for the classic Disney's Hercules Action Game directly in the Steam Deck Quick Access menu — no alt-tabbing required during gameplay.

  **Features**

  - Three difficulty modes: Beginner (9 levels), Medium (12 levels), and Herculian (12 levels)
  - Passwords shown as the game's own symbol icons (archer, centaur, Hercules, Pegasus, etc.)
  - Scrollable level list organized by difficulty
  - Password data sourced from GameFAQs

  **Plugin metadata**

| Field | Value |
| ------------- | ------------- |
| Name | Hercules Codes |
| Author | Rumen Novachkov |
| Tags  | utility, reference, game, cheat codes |
| Repository | https://github.com/RNovachkov/hercules-codes |