### PR TITLE
Add DeckCast to Plugin Store

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -359,3 +359,6 @@
 [submodule "plugins/decky-nonsteam-badges"]
 	path = plugins/decky-nonsteam-badges
 	url = https://github.com/sebet/decky-nonsteam-badges
+[submodule "plugins/DeckCast"]
+	path = plugins/DeckCast
+	url = https://github.com/dPacc/DeckCast.git


### PR DESCRIPTION
# Add DeckCast to Plugin Store

DeckCast is a Decky Loader plugin that turns your Steam Deck into a casting, recording, and sharing powerhouse — all from Gaming Mode.

**Key features:**
- 📺 **Live Cast** — Cast your Steam Deck screen to any browser on your local network at 60fps. Uses gpu-screen-recorder (Flatpak) for hardware-accelerated PipeWire capture, piped through FFmpeg to HLS segments served over HTTP. Browser player with volume, fullscreen, and PiP.
- 📲 **Wi-Fi Transfer** — Start a local web server, scan QR code, download recordings to any device. No size limits, resumable downloads, optional password protection.
- 🎬 **YouTube Upload** — Upload recordings to YouTube directly from Gaming Mode with title, description, tags, privacy settings. Background uploads.
- ✂️ **Clip Trimmer** — Trim clips instantly using FFmpeg codec copy (zero quality loss, no re-encoding).
- 📡 **Live Streaming** — Stream to YouTube, Twitch, or any RTMP endpoint.
- 📁 **Recording Browser** — Browse all Steam recordings with game name, duration, size. Scans internal storage and SD card.

**What makes it unique:** No other Decky plugin offers live screen casting to a browser. The closest existing plugins handle recording or file management, but none provide real-time 60fps screen sharing over the local network, YouTube uploads from Gaming Mode, or built-in clip trimming.

**Repository:** https://github.com/dPacc/DeckCast

## Task Checklist

### Developer

- [x] I am the original author or an authorized maintainer of this plugin.
- [x] I have abided by the licenses of the libraries I am utilizing, including attaching license notices where appropriate.
- [x] Generative AI was NOT used to write a majority of the code I am submitting.

### Plugin

- [x] I have verified that my plugin works properly on the Stable and Beta update channels of SteamOS.
- [x] I have verified my plugin is unique or provides more/alternative functionality to a plugin already on the store.

### Backend

- **No**: I am using a custom backend other than Python.
- **No**: I am using a tool or software from a 3rd party FOSS project that does not have it's dependencies [statically linked](https://en.wikipedia.org/wiki/Static_library).
- **No**: I am using a custom binary that has all of it's dependencies statically linked.

> Note: DeckCast uses gpu-screen-recorder installed as a system Flatpak (`com.dec05eba.gpu_screen_recorder`) and FFmpeg which is pre-installed on SteamOS. Neither is bundled with the plugin.

### Community

- [ ] I have tested and left feedback on two other [pull requests][pulls] for new or updating plugins.
- [ ] I have commented links to my testing report in this PR.

## Testing

- [ ] Tested by a third party on SteamOS Stable or Beta update channel.

[pulls]: https://github.com/steamdeckHomebrew/decky-plugin-database/pulls?q=is%3Apr+is%3Aopen+sort%3Acreated-desc+-status%3Afailure+-draft%3Atrue+-author%3A%40me