### PR TITLE
Add GeminiAI - Chat with Gemini directly from the Quick Access Menu

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -361,4 +361,4 @@
 	url = https://github.com/sebet/decky-nonsteam-badges
 [submodule "plugins/GeminiAI"]
 	path = plugins/GeminiAI
-	url = git@github.com/mark-lacdao/decky-gemini-plugin.git
+	url = https://github.com/mark-lacdao/decky-gemini-plugin.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -361,4 +361,4 @@
 	url = https://github.com/sebet/decky-nonsteam-badges
 [submodule "plugins/GeminiAI"]
 	path = plugins/GeminiAI
-	url = git@github-personal:mark-lacdao/decky-gemini-plugin.git
+	url = git@github.com/mark-lacdao/decky-gemini-plugin.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -361,4 +361,4 @@
 	url = https://github.com/sebet/decky-nonsteam-badges
 [submodule "plugins/GeminiAI"]
 	path = plugins/GeminiAI
-	url = https://github.com/mark-lacdao/decky-gemini-plugin
+	url = git@github-personal:mark-lacdao/decky-gemini-plugin.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -359,3 +359,6 @@
 [submodule "plugins/decky-nonsteam-badges"]
 	path = plugins/decky-nonsteam-badges
 	url = https://github.com/sebet/decky-nonsteam-badges
+[submodule "plugins/GeminiAI"]
+	path = plugins/GeminiAI
+	url = https://github.com/mark-lacdao/decky-gemini-plugin


### PR DESCRIPTION
# Add GeminiAI to Plugin Store

Chat with Google Gemini directly from your Steam Deck's Quick Access Menu (QAM) without switching to desktop mode. Supports multiple Gemini models (gemini-2.5-flash-lite, gemini-2.0-flash, gemini-1.5-pro) selectable via dropdown. API key stored securely via Decky's settings system. Users supply their own API key from aistudio.google.com.

## Task Checklist

### Developer

- [x] I am the original author or an authorized maintainer of this plugin.
- [x] I have abided by the licenses of the libraries I am utilizing, including attaching license notices where appropriate.
- [ ] Generative AI was NOT used to write a majority of the code I am submitting.

### Plugin

- [x] I have verified that my plugin works properly on the Stable and Beta update channels of SteamOS.
- [x] I have verified my plugin is unique or provides more/alternative functionality to a plugin already on the store.

### Backend

- **No**: I am using a custom backend other than Python.
- **No**: I am using a tool or software from a 3rd party FOSS project that does not have its dependencies statically linked.
- **No**: I am using a custom binary that has all of its dependencies statically linked.

### Community

- [ ] I have tested and left feedback on two other pull requests for new or updating plugins.
- [ ] I have commented links to my testing report in this PR.

## Testing

- [x] Tested on a Steamdeck OS Version 3.7.22, Build 20260430.1.
