### PR TITLE
Update Deck Shelves to v3.0.0

### DIFF
--- a/.github/tmp/checklist.txt
+++ b/.github/tmp/checklist.txt
@@ -1,0 +1,26 @@
+## Task Checklist
+
+### Developer
+
+- [x] I am the original author or an authorized maintainer of this plugin.
+- [x] I have abided by the licenses of the libraries I am utilizing, including attaching license notices where appropriate.
+
+### Plugin
+
+- [x] I have verified that my plugin works properly on the Stable and Beta update channels of SteamOS.
+- [x] I have verified my plugin is unique or provides more/alternative functionality to a plugin already on the store.
+
+### Backend
+
+- **No**: I am using a custom backend other than Python.
+- **No**: I am using a tool or software from a 3rd party FOSS project that does not have it's dependencies [statically linked](https://en.wikipedia.org/wiki/Static_library).
+- **No**: I am using a custom binary that has all of it's dependencies statically linked.
+
+### Community
+
+- [ ] I have tested and left feedback on two other [pull requests][pulls] for new or updating plugins.
+- [ ] I have commented links to my testing report in this PR.
+
+## Testing
+
+- [ ] Tested by a third party on SteamOS Stable or Beta update channel.


### PR DESCRIPTION
## Changes since 2.0.0

* Added
    - **Hero art behind shelves.** Each shelf (regular or smart) has an "Enable hero art" toggle in the edit modal's Visual tab — turn it on and the focused game's artwork appears behind that shelf, following it wherever it sits. A new global toggle in the QAM (Visual section) turns hero art on for *every* shelf at once.
    - **Cloud-play sub-toggle for the online shelves** (QAM Online Features + Edit Shelf modal). Cloud-only catalogue entries — like Xbox Cloud Gaming games surfaced via Unifideck's Microsoft Store integration — are now kept visible on your wishlist / store-on-sale shelves by default, even with "Include non-Steam shortcuts" on. Locally-installed non-Steam games (Epic / GOG / Amazon / Ubisoft) still count as owned. Flip the new sub-toggle on if you want cloud-only entries treated as owned too.
    - **Theme integration for shelves.** Themes installed via CSS Loader now reach Deck Shelves' promoted shelves automatically: **No Hero Gradient** clears the hero mask; **Hero Fullscreen / Art Hero FullBG** snaps the shelf to 100vh with the hero filling the screen; **No Home Text** hides DS card labels (only under "Force CSS Loader themes"). **Transparency Tweaks** dims unfocused card portraits; **Round / More Round** rounds the NEW and discount tags.
    - **"Force CSS Loader themes" only shows when CSS Loader is installed.** No more dead toggle on devices without the plugin.
    - **Focus Highlight Color theme support.** Install the theme and Deck Shelves auto-adjusts: with Round Compatibility enabled, DS card focus disappears (matching the theme's native behaviour); without it, the colored animated outline shows behind the NEW / discount badge with a clean 1 px gap on every side.
    - **Game Cover Shine Animation Color theme support.** The shine sweep on focus reaches Deck Shelves cards automatically — no extra configuration needed.
    - **NEW / discount badges always on top.** Badges now render in a separate overlay above the entire UI, so they stay in front of theme focus rings and other Steam overlays no matter the theme combination.
   
* Changed
    - **The Edit Shelf modal "found X games" count and preview now match the rendered shelf.** Toggling per-shelf "Ignore games I own" or the new cloud-play sub-toggle inside the modal updates both immediately.
       
* Fixed
    - **Hero art briefly flashing then vanishing as you d-pad between cards** (with the "Force themes" toggle OFF). Smoothed out.
    - **Inter-shelf hero blending refined.** With recents hidden, the first DS shelf's hero reaches the top of the screen, and the transition into the second shelf has a subtler fade. With native recents visible, the first DS shelf hero overlaps native with a smoother fade instead of a black band between the two arts.
    - **D-pad up no longer makes the home flicker / reload.** Pressing up from the top shelf used to dip into the hidden Recents row and jolt the screen — focus now stays on your shelves.
    - **No more flash of reloading shelves on the first move after a Steam restart.**
    - **Leaving a shelf keeps the last game's hero art** instead of snapping back to the first game.
    - **Highlighted-card size and TiltedHome card spacing** are correct again with "Match native card size" on.
    - **Refresh works on smart shelf cards** from the long-press / Menu context menu.

## Task Checklist

### Developer

- [x] I am the original author or an authorized maintainer of this plugin.
- [x] I have abided by the licenses of the libraries I am utilizing, including attaching license notices where appropriate.

### Plugin

- [x] I have verified that my plugin works properly on the Stable and Beta update channels of SteamOS.
- [x] I have verified my plugin is unique or provides more/alternative functionality to a plugin already on the store.

### Backend

- **No**: I am using a custom backend other than Python.
- **No**: I am using a tool or software from a 3rd party FOSS project that does not have it's dependencies [statically linked](https://en.wikipedia.org/wiki/Static_library).
- **No**: I am using a custom binary that has all of it's dependencies statically linked.

### Community

- [ ] I have tested and left feedback on two other [pull requests][pulls] for new or updating plugins.
- [ ] I have commented links to my testing report in this PR.

## Testing

- [ ] Tested by a third party on SteamOS Stable or Beta update channel.

[pulls]: https://github.com/SteamDeckHomebrew/decky-plugin-database/pulls?q=is%3Apr+is%3Aopen+sort%3Acreated-desc+-status%3Afailure+-draft%3Atrue+-author%3A%40me
