### PR TITLE
Add KDEck

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -368,3 +368,6 @@
 [submodule "plugins/Deck-Shelves"]
 	path = plugins/Deck-Shelves
 	url = https://github.com/santojon/Deck-Shelves.git
+[submodule "plugins/KDEck"]
+	path = plugins/KDEck
+	url = https://github.com/BRiAn3274/KDEck.git


### PR DESCRIPTION
# Add KDEck to Plugin Store

KDEck is a Decky Loader plugin for Steam Deck game mode. It provides a minimal KDE Connect-compatible receiver so a phone can send clipboard text into the Decky panel and files into /home/deck/Downloads.

## Submitted Version

This PR submits KDEck `v0.4.2` for Plugin Store review.

`v0.4.2` is the current stable release I consider mature enough for store submission. Later versions exist, but they are currently treated as beta builds because they have had less testing. They are not part of this store submission.

The submodule is intentionally pinned to the `v0.4.2` commit instead of the latest beta branch.

## Task Checklist

### Developer

- [x] I am the original author or an authorized maintainer of this plugin.
- [x] I have abided by the licenses of the libraries I am utilizing, including attaching license notices where appropriate.
- [x] Generative AI was NOT used to write a majority of the code I am submitting.

### Plugin

- [ ] I have verified that my plugin works properly on the Stable and Beta update channels of SteamOS.
- [x] I have verified my plugin is unique or provides more/alternative functionality to a plugin already on the store.

### Backend

- **No**: I am using a custom backend other than Python.
- **No**: I am using a tool or software from a 3rd party FOSS project that does not have it's dependencies statically linked.
- **No**: I am using a custom binary that has all of it's dependencies statically linked.

KDEck uses a Python backend. It can call SteamOS-provided KDE Connect tools for legacy diagnostics, but the user-facing receive path uses KDEck's own minimal LAN receiver.

### Scope

- Receives KDE Connect clipboard text from a phone.
- Receives KDE Connect shared files from a phone.
- Does not provide notifications, SMS, remote input, media control, or the full KDE Connect desktop feature set.

### Isolation

- Uses a separate KDEck device ID, certificate, and plugin data directory.
- Does not register org.kde.kdeconnect.
- Does not write to the desktop KDE Connect pairing configuration.
- Pauses its receiver in Plasma desktop mode and resumes in game mode.

### Community

- [ ] I have tested and left feedback on two other pull requests for new or updating plugins.
- [ ] I have commented links to my testing report in this PR.

## Testing

- [ ] Tested by a third party on SteamOS Preview update channel.

Self-tested on SteamOS Stable with Steam Deck OLED:
- Plugin loads in Decky Loader.
- Android KDE Connect can discover and pair with KDEck.
- Clipboard receive works.
- File receive saves to /home/deck/Downloads.
- Desktop mode isolation verified with KDEck receiver pause/resume.