### PR TITLE
Add warp-deck plugin

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -368,3 +368,6 @@
 [submodule "plugins/Deck-Shelves"]
 	path = plugins/Deck-Shelves
 	url = https://github.com/santojon/Deck-Shelves.git
+[submodule "plugins/warp-deck"]
+	path = plugins/warp-deck
+	url = https://github.com/rosakodu/warp-deck


### PR DESCRIPTION
# Add warp-deck to Plugin Store

A Decky Loader plugin for bypassing DPI and connecting to Cloudflare WARP via AmneziaWG. It automatically registers anonymous Cloudflare accounts, generates obfuscated WireGuard configurations (using HTTP3/QUIC handshake signatures), and connects natively on the Steam Deck to bypass DPI blocking without requiring paid VPN subscriptions.

## Task Checklist

### Developer

- [x] I am the original author or an authorized maintainer of this plugin.
- [x] I have abided by the licenses of the libraries I am utilizing, including attaching license notices where appropriate.
- [ ] Generative AI was NOT used to write a majority of the code I am submitting.

### Plugin

- [x] I have verified that my plugin works properly on the Stable and Beta update channels of SteamOS.
- [x] I have verified my plugin is unique or provides more/alternative functionality to a plugin already on the store.

### Backend

- **No**: I am using a custom backend other than Python.
- **Yes**: I am using a tool or software from a 3rd party FOSS project that does not have it's dependencies statically linked.
- **No**: I am using a custom binary that has all of it's dependencies statically linked.

### Community

- [ ] I have tested and left feedback on two other pull requests for new or updating plugins.
- [ ] I have commented links to my testing report in this PR.

## Testing

- [ ] Tested by a third party on SteamOS Preview update channel.