### PR TITLE
Add Deck Stats plugin

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -368,3 +368,6 @@
 [submodule "plugins/Deck-Shelves"]
 	path = plugins/Deck-Shelves
 	url = https://github.com/santojon/Deck-Shelves.git
+[submodule "plugins/deck-stats"]
+	path = plugins/deck-stats
+	url = https://github.com/iwsen/deck-stats.git


### PR DESCRIPTION
# Add Deck Stats to Plugin Store

Deck Stats is a per-game playtime tracker for Steam Deck. It automatically detects running games, records sessions locally in SQLite, and provides per-game statistics, activity heatmaps, play streaks, milestones, goals, session editing, JSON export/import, and separate docked/handheld playtime.

## Task Checklist

### Developer

- [x] I am the original author or an authorized maintainer of this plugin.
- [x] I have abided by the licenses of the libraries I am utilizing, including attaching license notices where appropriate.
- [x] Generative AI was NOT used to write a majority of the code I am submitting.

### Plugin

- [x] I have verified that my plugin works properly on the Stable and Beta update channels of SteamOS.
- [x] I have verified my plugin is unique or provides more/alternative functionality to a plugin already on the store.

### Backend

- **No**: I am using a custom backend other than Python.
- **No**: I am using a tool or software from a 3rd party FOSS project that does not have it's dependencies statically linked.
- **No**: I am using a custom binary that has all of it's dependencies statically linked.

### Community

- [ ] I have tested and left feedback on two other pull requests for new or updating plugins.
- [ ] I have commented links to my testing report in this PR.

## Testing

- [ ] Tested by a third party on SteamOS Stable or Beta update channel.