### PR TITLE
Add Non-Steam Fullscreen

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -368,3 +368,6 @@
 [submodule "plugins/Deck-Shelves"]
 	path = plugins/Deck-Shelves
 	url = https://github.com/santojon/Deck-Shelves.git
+[submodule "plugins/non-steam-fullscreen"]
+	path = plugins/non-steam-fullscreen
+	url = https://github.com/BohdanNosenko/non-steam-fullscreen-decky-plugin.git


### PR DESCRIPTION
# Add Non-Steam Fullscreen to Plugin Store
Non-Steam Fullscreen is a Decky Loader plugin that dynamically wraps non-Steam desktop applications (such as Flatpaks, AppImages, and local binaries) in a nested Gamescope session. This forces them to render in proper borderless fullscreen in SteamOS Gaming Mode, bypassing default window manager scaling constraints.

### Key Features:
* **Dynamic Resolution Adaptation:** Automatically queries the active display resolution on launch to support both the internal screen and external docked monitors of any resolution.
* **OSK Suppression:** Exports toolkit-specific environment overrides to suppress the virtual keyboard (OSK) from automatically popping up on launch, while preserving manual `Steam + X` summoning.
* **Moondeck Filtering:** Automatically detects and filters out remote PC streaming shortcuts (like Moondeck games) that are managed by external hosts.
* **Safe Client Reload:** Gracefully restarts the Steam client via SIGTERM with write-protection locks on `shortcuts.vdf` to prevent configurations from being overwritten or triggering the "Verifying Installation" loop.

## Task Checklist

### Developer

- [x] I am the original author or an authorized maintainer of this plugin.
- [x] I have abided by the licenses of the libraries I am utilizing, including attaching license notices where appropriate.
- [x] Generative AI was NOT used to write a majority of the code I am submitting.

### Plugin

- [x] I have verified that my plugin works properly on the Stable and Beta update channels of SteamOS.
- [x] I have verified my plugin is unique or provides more/alternative functionality to a plugin already on the store.

### Backend

- **No**: I am using a custom backend other than Python.
- **No**: I am using a tool or software from a 3rd party FOSS project that does not have it's dependencies [statically linked](https://en.wikipedia.org/wiki/Static_library).
- **No**: I am using a custom binary that has all of it's dependencies statically linked.

### Community

- [ ] I have tested and left feedback on two other [pull requests][pulls] for new or updating plugins.
- [ ] I have commented links to my testing report in this PR.

## Testing

- [ ] Tested by a third party on SteamOS Stable or Beta update channel.

[pulls]: https://github.com/steamdeckHomebrew/decky-plugin-database/pulls?q=is%3Apr+is%3Aopen+sort%3Acreated-desc+-status%3Afailure+-draft%3Atrue+-author%3A%40me